### PR TITLE
[DOR-179][AO] link errors to the date sub-fields

### DIFF
--- a/app/uk/gov/hmrc/traderservices/controllers/Time12FieldHelper.scala
+++ b/app/uk/gov/hmrc/traderservices/controllers/Time12FieldHelper.scala
@@ -80,22 +80,27 @@ object Time12FieldHelper {
   def validTimeFields(fieldName: String, required: Boolean): Constraint[TimeParts] =
     Constraint[TimeParts](s"constraint.$fieldName.time-fields") {
       case (h, m, p) if h.isEmpty && m.isEmpty && p.isEmpty =>
-        if (required) Invalid(ValidationError(s"error.$fieldName.all.required")) else Valid
+        if (required) Invalid(ValidationError(Seq("subfieldFocus=hour", s"error.$fieldName.all.required"))) else Valid
       case (h, m, p) if h.isEmpty && m.isEmpty && isValidPeriod(p) =>
-        if (required) Invalid(ValidationError(s"error.$fieldName.all.required")) else Valid
+        if (required) Invalid(ValidationError(Seq("subfieldFocus=hour", s"error.$fieldName.all.required"))) else Valid
       case (h, m, p) =>
         val errors = Seq(
-          if (h.isEmpty) Some(ValidationError(s"error.$fieldName.hour.required"))
-          else if (!h.forall(_.isDigit)) Some(ValidationError(s"error.$fieldName.hour.invalid-digits"))
+          // validate hour
+          if (h.isEmpty) Some(ValidationError(Seq("subfieldFocus=hour", s"error.$fieldName.hour.required")))
+          else if (!h.forall(_.isDigit))
+            Some(ValidationError(Seq("subfieldFocus=hour", s"error.$fieldName.hour.invalid-digits")))
           else if (isValidHour(h)) None
-          else Some(ValidationError(s"error.$fieldName.hour.invalid-value")),
-          if (m.isEmpty) Some(ValidationError(s"error.$fieldName.minutes.required"))
-          else if (!m.forall(_.isDigit)) Some(ValidationError(s"error.$fieldName.minutes.invalid-digits"))
+          else Some(ValidationError(Seq("subfieldFocus=hour", s"error.$fieldName.hour.invalid-value"))),
+          // validate minutes
+          if (m.isEmpty) Some(ValidationError(Seq("subfieldFocus=minutes", s"error.$fieldName.minutes.required")))
+          else if (!m.forall(_.isDigit))
+            Some(ValidationError(Seq("subfieldFocus=minutes", s"error.$fieldName.minutes.invalid-digits")))
           else if (isValidMinutes(m)) None
-          else Some(ValidationError(s"error.$fieldName.minutes.invalid-value")),
-          if (p.isEmpty) Some(ValidationError(s"error.$fieldName.period.required"))
+          else Some(ValidationError(Seq("subfieldFocus=minutes", s"error.$fieldName.minutes.invalid-value"))),
+          // validate am-pm
+          if (p.isEmpty) Some(ValidationError(Seq("subfieldFocus=period", s"error.$fieldName.period.required")))
           else if (isValidPeriod(p)) None
-          else Some(ValidationError(s"error.$fieldName.period.invalid-value"))
+          else Some(ValidationError(Seq("subfieldFocus=period", s"error.$fieldName.period.invalid-value")))
         ).collect { case Some(e) => e }
 
         if (errors.isEmpty) Valid else Invalid(errors)

--- a/app/uk/gov/hmrc/traderservices/controllers/Time24FieldHelper.scala
+++ b/app/uk/gov/hmrc/traderservices/controllers/Time24FieldHelper.scala
@@ -79,17 +79,21 @@ object Time24FieldHelper {
   def validTimeFields(fieldName: String, required: Boolean): Constraint[TimeParts] =
     Constraint[TimeParts](s"constraint.$fieldName.time-fields") {
       case (h, m) if h.isEmpty && m.isEmpty =>
-        if (required) Invalid(ValidationError(s"error.$fieldName.all.required")) else Valid
+        if (required) Invalid(ValidationError(Seq("subfieldFocus=hour", s"error.$fieldName.all.required"))) else Valid
       case (h, m) =>
         val errors = Seq(
-          if (h.isEmpty) Some(ValidationError(s"error.$fieldName.hour.required"))
-          else if (!h.forall(_.isDigit)) Some(ValidationError(s"error.$fieldName.hour.invalid-digits"))
+          // validate hour
+          if (h.isEmpty) Some(ValidationError(Seq("subfieldFocus=hour", s"error.$fieldName.hour.required")))
+          else if (!h.forall(_.isDigit))
+            Some(ValidationError(Seq("subfieldFocus=hour", s"error.$fieldName.hour.invalid-digits")))
           else if (isValidHour(h)) None
-          else Some(ValidationError(s"error.$fieldName.hour.invalid-value")),
-          if (m.isEmpty) Some(ValidationError(s"error.$fieldName.minutes.required"))
-          else if (!m.forall(_.isDigit)) Some(ValidationError(s"error.$fieldName.minutes.invalid-digits"))
+          else Some(ValidationError(Seq("subfieldFocus=hour", s"error.$fieldName.hour.invalid-value"))),
+          // validate minutes
+          if (m.isEmpty) Some(ValidationError(Seq("subfieldFocus=minutes", s"error.$fieldName.minutes.required")))
+          else if (!m.forall(_.isDigit))
+            Some(ValidationError(Seq("subfieldFocus=minutes", s"error.$fieldName.minutes.invalid-digits")))
           else if (isValidMinutes(m)) None
-          else Some(ValidationError(s"error.$fieldName.minutes.invalid-value"))
+          else Some(ValidationError(Seq("subfieldFocus=minutes", s"error.$fieldName.minutes.invalid-value")))
         ).collect { case Some(e) => e }
 
         if (errors.isEmpty) Valid else Invalid(errors)

--- a/app/uk/gov/hmrc/traderservices/views/components/errorSummary.scala.html
+++ b/app/uk/gov/hmrc/traderservices/views/components/errorSummary.scala.html
@@ -21,7 +21,11 @@
     @if(errors.nonEmpty) {
         @defining(errors.map { error =>
             val id = if(error.key == "") { errorId.getOrElse("") } else {
-                error.key + errorFieldSuffix.fold("")(suffix => s".$suffix")
+                val subfieldFocus = error.messages.headOption match {
+                    case Some(m) if m.startsWith("subfieldFocus=") => "."+m.drop("subfieldFocus=".length)
+                    case _ => ""
+                }
+                error.key + subfieldFocus + errorFieldSuffix.fold("")(suffix => s".$suffix")
             }
             ErrorLink(
                 href = Some(s"#$id"),

--- a/test/uk/gov/hmrc/traderservices/controllers/DateFieldHelperSpec.scala
+++ b/test/uk/gov/hmrc/traderservices/controllers/DateFieldHelperSpec.scala
@@ -151,13 +151,10 @@ class DateFieldHelperSpec extends UnitSpec with FormMappingMatchers {
       "error.foo.day.required"
     )
     dateFieldsMapping("foo").bind(Map("year" -> "2020a", "month" -> "13", "day" -> "0")) should haveOnlyErrors(
-      "error.foo.year.invalid-digits",
       "error.foo.all.invalid-value"
     )
     dateFieldsMapping("foo").bind(Map("year" -> "2020a", "month" -> "13a", "day" -> "a0")) should haveOnlyErrors(
-      "error.foo.year.invalid-digits",
-      "error.foo.month.invalid-digits",
-      "error.foo.day.invalid-digits"
+      "error.foo.all.invalid-value"
     )
     dateFieldsMapping("foo").bind(Map("year" -> "0", "month" -> "0", "day" -> "0")) should haveOnlyErrors(
       "error.foo.all.invalid-value"
@@ -201,15 +198,12 @@ class DateFieldHelperSpec extends UnitSpec with FormMappingMatchers {
       "error.bar.day.required"
     )
     optionalDateFieldsMapping("bar").bind(Map("year" -> "2020a", "month" -> "13", "day" -> "0")) should haveOnlyErrors(
-      "error.bar.year.invalid-digits",
       "error.bar.all.invalid-value"
     )
     optionalDateFieldsMapping("bar").bind(
       Map("year" -> "2020a", "month" -> "13a", "day" -> "a0")
     ) should haveOnlyErrors(
-      "error.bar.year.invalid-digits",
-      "error.bar.month.invalid-digits",
-      "error.bar.day.invalid-digits"
+      "error.bar.all.invalid-value"
     )
     optionalDateFieldsMapping("bar").bind(Map("year" -> "0", "month" -> "0", "day" -> "0")) should haveOnlyErrors(
       "error.bar.all.invalid-value"

--- a/test/uk/gov/hmrc/traderservices/controllers/DeclarationDetailsFormSpec.scala
+++ b/test/uk/gov/hmrc/traderservices/controllers/DeclarationDetailsFormSpec.scala
@@ -87,63 +87,81 @@ class DeclarationDetailsFormSpec extends UnitSpec with FormMatchers {
     "report an error when entryDate.year is missing" in {
       val input = formInput.updated("entryDate.year", "")
       form.bind(input).value shouldBe None
-      form.bind(input).errors should haveOnlyErrors(FormError("entryDate", "error.entryDate.year.required"))
+      form.bind(input).errors should haveOnlyErrors(
+        FormError("entryDate", Seq("subfieldFocus=year", "error.entryDate.year.required"))
+      )
     }
 
     "report an error when entryDate.year is invalid" in {
       val input = formInput.updated("entryDate.year", "197B")
       form.bind(input).value shouldBe None
-      form.bind(input).errors should haveOnlyErrors(FormError("entryDate", "error.entryDate.year.invalid-digits"))
+      form.bind(input).errors should haveOnlyErrors(
+        FormError("entryDate", Seq("subfieldFocus=year", "error.entryDate.year.invalid-digits"))
+      )
     }
 
     "report an error when entryDate.day is invalid - contains digit and letter" in {
       val input = formInput.updated("entryDate.day", "0X")
       form.bind(input).value shouldBe None
-      form.bind(input).errors should haveOnlyErrors(FormError("entryDate", "error.entryDate.day.invalid-digits"))
+      form.bind(input).errors should haveOnlyErrors(
+        FormError("entryDate", Seq("subfieldFocus=day", "error.entryDate.day.invalid-digits"))
+      )
     }
 
     "report an error when entryDate.day is invalid - contains value out-of-scope" in {
       val input = formInput.updated("entryDate.day", "32")
       form.bind(input).value shouldBe None
-      form.bind(input).errors should haveOnlyErrors(FormError("entryDate", "error.entryDate.day.invalid-value"))
+      form.bind(input).errors should haveOnlyErrors(
+        FormError("entryDate", Seq("subfieldFocus=day", "error.entryDate.day.invalid-value"))
+      )
     }
 
     "report an error when entryDate.month is invalid - contains digit and letter" in {
       val input = formInput.updated("entryDate.month", "1X")
       form.bind(input).value shouldBe None
-      form.bind(input).errors should haveOnlyErrors(FormError("entryDate", "error.entryDate.month.invalid-digits"))
+      form.bind(input).errors should haveOnlyErrors(
+        FormError("entryDate", Seq("subfieldFocus=month", "error.entryDate.month.invalid-digits"))
+      )
     }
 
     "report an error when entryDate.month is invalid - contains value out-of-scope" in {
       val input = formInput.updated("entryDate.month", "13")
       form.bind(input).value shouldBe None
-      form.bind(input).errors should haveOnlyErrors(FormError("entryDate", "error.entryDate.month.invalid-value"))
+      form.bind(input).errors should haveOnlyErrors(
+        FormError("entryDate", Seq("subfieldFocus=month", "error.entryDate.month.invalid-value"))
+      )
     }
 
     "disallow empty entryDate.day" in {
       val input = formInput.updated("entryDate.day", "")
       form.bind(input).value shouldBe None
-      form.bind(input).errors should haveOnlyError(FormError("entryDate", "error.entryDate.day.required"))
+      form.bind(input).errors should haveOnlyError(
+        FormError("entryDate", Seq("subfieldFocus=day", "error.entryDate.day.required"))
+      )
     }
 
     "report an error when empty entryDate.month " in {
       val input = formInput.updated("entryDate.month", "")
       form.bind(input).value shouldBe None
-      form.bind(input).errors should haveOnlyErrors(FormError("entryDate", "error.entryDate.month.required"))
+      form.bind(input).errors should haveOnlyErrors(
+        FormError("entryDate", Seq("subfieldFocus=month", "error.entryDate.month.required"))
+      )
     }
 
     "report an error when entryDate in the future" in {
       val input = formInputFor(date.plusDays(1))
       form.bind(input).value shouldBe None
-      form.bind(input).errors should haveOnlyErrors(FormError("entryDate", "error.entryDate.all.invalid-value-future"))
+      form.bind(input).errors should haveOnlyErrors(
+        FormError("entryDate", Seq("subfieldFocus=day", "error.entryDate.all.invalid-value-future"))
+      )
     }
 
     "disallow empty entryDate.day and empty entryDate.month" in {
       val input = formInput.updated("entryDate.day", "").updated("entryDate.month", "")
       form.bind(input).value shouldBe None
       form.bind(input).errors should haveOnlyErrors(
-        FormError("entryDate", "error.entryDate.month.required"),
-        FormError("entryDate", "error.entryDate.day.required")
+        FormError("entryDate", Seq("subfieldFocus=month", "error.entryDate.month.required")),
+        FormError("entryDate", Seq("subfieldFocus=day", "error.entryDate.day.required"))
       )
     }
   }

--- a/test/uk/gov/hmrc/traderservices/controllers/FormFieldMappingsSpec.scala
+++ b/test/uk/gov/hmrc/traderservices/controllers/FormFieldMappingsSpec.scala
@@ -147,12 +147,10 @@ class FormFieldMappingsSpec extends UnitSpec with FormMappingMatchers {
         "error.entryDate.year.required"
       ).and(haveError[LocalDate]("error.entryDate.month.invalid-digits"))
       entryDateMapping.bind(Map("year" -> "2020", "month" -> "0A", "day" -> "2AA")) should haveOnlyErrors[LocalDate](
-        "error.entryDate.month.invalid-digits",
-        "error.entryDate.day.invalid-digits"
+        "error.entryDate.all.invalid-value"
       )
       entryDateMapping.bind(Map("year" -> "2021", "month" -> "0A", "day" -> "2AA")) should haveOnlyErrors[LocalDate](
-        "error.entryDate.month.invalid-digits",
-        "error.entryDate.day.invalid-digits"
+        "error.entryDate.all.invalid-value"
       )
       entryDateMapping.bind(Map("year" -> "2050", "month" -> "01", "day" -> "01")) should haveOnlyError[LocalDate](
         "error.entryDate.all.invalid-value-future"
@@ -403,8 +401,7 @@ class FormFieldMappingsSpec extends UnitSpec with FormMappingMatchers {
       )
       mandatoryDateOfArrivalMapping
         .bind(Map("year" -> "XX", "month" -> "13", "day" -> "")) should haveOnlyErrors(
-        "error.dateOfArrival.year.invalid-digits",
-        "error.dateOfArrival.month.invalid-value",
+        "error.dateOfArrival.all.invalid-value",
         "error.dateOfArrival.day.required"
       )
     }
@@ -452,8 +449,7 @@ class FormFieldMappingsSpec extends UnitSpec with FormMappingMatchers {
       )
       optionalDateOfArrivalMapping
         .bind(Map("year" -> "XX", "month" -> "13", "day" -> "")) should haveOnlyErrors(
-        "error.dateOfArrival.year.invalid-digits",
-        "error.dateOfArrival.month.invalid-value",
+        "error.dateOfArrival.all.invalid-value",
         "error.dateOfArrival.day.required"
       )
     }

--- a/test/uk/gov/hmrc/traderservices/controllers/Time12FieldHelperSpec.scala
+++ b/test/uk/gov/hmrc/traderservices/controllers/Time12FieldHelperSpec.scala
@@ -84,41 +84,46 @@ class Time12FieldHelperSpec extends UnitSpec with FormMappingMatchers {
       val validate = t => validTimeFields("foo", required = true)(t)
       validate(("12", "00", "AM")) shouldBe Valid
       validate(("12", "00", "PM")) shouldBe Valid
-      validate(("", "", "")) shouldBe Invalid(ValidationError("error.foo.all.required"))
-      validate(("", "", "AM")) shouldBe Invalid(Seq(ValidationError("error.foo.all.required")))
+      validate(("", "", "")) shouldBe Invalid(ValidationError(Seq("subfieldFocus=hour", "error.foo.all.required")))
+      validate(("", "", "AM")) shouldBe Invalid(
+        Seq(ValidationError(Seq("subfieldFocus=hour", "error.foo.all.required")))
+      )
       validate(("12", "", "AM")) shouldBe Invalid(
-        Seq(ValidationError("error.foo.minutes.required"))
+        Seq(ValidationError(Seq("subfieldFocus=minutes", "error.foo.minutes.required")))
       )
       validate(("", "59", "AM")) shouldBe Invalid(
-        Seq(ValidationError("error.foo.hour.required"))
+        Seq(ValidationError(Seq("subfieldFocus=hour", "error.foo.hour.required")))
       )
       validate(("", "59", "")) shouldBe Invalid(
-        Seq(ValidationError("error.foo.hour.required"), ValidationError("error.foo.period.required"))
+        Seq(
+          ValidationError(Seq("subfieldFocus=hour", "error.foo.hour.required")),
+          ValidationError(Seq("subfieldFocus=period", "error.foo.period.required"))
+        )
       )
       validate(("00", "", "SM")) shouldBe Invalid(
         Seq(
-          ValidationError("error.foo.hour.invalid-value"),
-          ValidationError("error.foo.minutes.required"),
-          ValidationError("error.foo.period.invalid-value")
+          ValidationError(Seq("subfieldFocus=hour", "error.foo.hour.invalid-value")),
+          ValidationError(Seq("subfieldFocus=minutes", "error.foo.minutes.required")),
+          ValidationError(Seq("subfieldFocus=period", "error.foo.period.invalid-value"))
         )
       )
       validate(("00", "60", "")) shouldBe Invalid(
         Seq(
-          ValidationError("error.foo.hour.invalid-value"),
-          ValidationError("error.foo.minutes.invalid-value"),
-          ValidationError("error.foo.period.required")
+          ValidationError(Seq("subfieldFocus=hour", "error.foo.hour.invalid-value")),
+          ValidationError(Seq("subfieldFocus=minutes", "error.foo.minutes.invalid-value")),
+          ValidationError(Seq("subfieldFocus=period", "error.foo.period.required"))
         )
       )
       validate(("01", "00", "M")) shouldBe Invalid(
         Seq(
-          ValidationError("error.foo.period.invalid-value")
+          ValidationError(Seq("subfieldFocus=period", "error.foo.period.invalid-value"))
         )
       )
       validate(("0a", "b0", "M")) shouldBe Invalid(
         Seq(
-          ValidationError("error.foo.hour.invalid-digits"),
-          ValidationError("error.foo.minutes.invalid-digits"),
-          ValidationError("error.foo.period.invalid-value")
+          ValidationError(Seq("subfieldFocus=hour", "error.foo.hour.invalid-digits")),
+          ValidationError(Seq("subfieldFocus=minutes", "error.foo.minutes.invalid-digits")),
+          ValidationError(Seq("subfieldFocus=period", "error.foo.period.invalid-value"))
         )
       )
     }
@@ -132,44 +137,47 @@ class Time12FieldHelperSpec extends UnitSpec with FormMappingMatchers {
       validate(("", "", "PM")) shouldBe Valid
       validate(("", "", "MP")) shouldBe Invalid(
         Seq(
-          ValidationError("error.foo.hour.required"),
-          ValidationError("error.foo.minutes.required"),
-          ValidationError("error.foo.period.invalid-value")
+          ValidationError(Seq("subfieldFocus=hour", "error.foo.hour.required")),
+          ValidationError(Seq("subfieldFocus=minutes", "error.foo.minutes.required")),
+          ValidationError(Seq("subfieldFocus=period", "error.foo.period.invalid-value"))
         )
       )
       validate(("12", "", "AM")) shouldBe Invalid(
-        Seq(ValidationError("error.foo.minutes.required"))
+        Seq(ValidationError(Seq("subfieldFocus=minutes", "error.foo.minutes.required")))
       )
       validate(("", "59", "AM")) shouldBe Invalid(
-        Seq(ValidationError("error.foo.hour.required"))
+        Seq(ValidationError(Seq("subfieldFocus=hour", "error.foo.hour.required")))
       )
       validate(("", "59", "")) shouldBe Invalid(
-        Seq(ValidationError("error.foo.hour.required"), ValidationError("error.foo.period.required"))
+        Seq(
+          ValidationError(Seq("subfieldFocus=hour", "error.foo.hour.required")),
+          ValidationError(Seq("subfieldFocus=period", "error.foo.period.required"))
+        )
       )
       validate(("00", "", "SM")) shouldBe Invalid(
         Seq(
-          ValidationError("error.foo.hour.invalid-value"),
-          ValidationError("error.foo.minutes.required"),
-          ValidationError("error.foo.period.invalid-value")
+          ValidationError(Seq("subfieldFocus=hour", "error.foo.hour.invalid-value")),
+          ValidationError(Seq("subfieldFocus=minutes", "error.foo.minutes.required")),
+          ValidationError(Seq("subfieldFocus=period", "error.foo.period.invalid-value"))
         )
       )
       validate(("00", "60", "")) shouldBe Invalid(
         Seq(
-          ValidationError("error.foo.hour.invalid-value"),
-          ValidationError("error.foo.minutes.invalid-value"),
-          ValidationError("error.foo.period.required")
+          ValidationError(Seq("subfieldFocus=hour", "error.foo.hour.invalid-value")),
+          ValidationError(Seq("subfieldFocus=minutes", "error.foo.minutes.invalid-value")),
+          ValidationError(Seq("subfieldFocus=period", "error.foo.period.required"))
         )
       )
       validate(("01", "00", "M")) shouldBe Invalid(
         Seq(
-          ValidationError("error.foo.period.invalid-value")
+          ValidationError(Seq("subfieldFocus=period", "error.foo.period.invalid-value"))
         )
       )
       validate(("0a", "b0", "M")) shouldBe Invalid(
         Seq(
-          ValidationError("error.foo.hour.invalid-digits"),
-          ValidationError("error.foo.minutes.invalid-digits"),
-          ValidationError("error.foo.period.invalid-value")
+          ValidationError(Seq("subfieldFocus=hour", "error.foo.hour.invalid-digits")),
+          ValidationError(Seq("subfieldFocus=minutes", "error.foo.minutes.invalid-digits")),
+          ValidationError(Seq("subfieldFocus=period", "error.foo.period.invalid-value"))
         )
       )
     }

--- a/test/uk/gov/hmrc/traderservices/controllers/Time24FieldHelperSpec.scala
+++ b/test/uk/gov/hmrc/traderservices/controllers/Time24FieldHelperSpec.scala
@@ -83,33 +83,33 @@ class Time24FieldHelperSpec extends UnitSpec with FormMappingMatchers {
       val validate = t => validTimeFields("foo", required = true)(t)
       validate(("12", "00")) shouldBe Valid
       validate(("12", "00")) shouldBe Valid
-      validate(("", "")) shouldBe Invalid(ValidationError("error.foo.all.required"))
-      validate(("", "")) shouldBe Invalid(Seq(ValidationError("error.foo.all.required")))
+      validate(("", "")) shouldBe Invalid(ValidationError(Seq("subfieldFocus=hour", "error.foo.all.required")))
+      validate(("", "")) shouldBe Invalid(Seq(ValidationError(Seq("subfieldFocus=hour", "error.foo.all.required"))))
       validate(("12", "")) shouldBe Invalid(
-        Seq(ValidationError("error.foo.minutes.required"))
+        Seq(ValidationError(Seq("subfieldFocus=minutes", "error.foo.minutes.required")))
       )
       validate(("", "59")) shouldBe Invalid(
-        Seq(ValidationError("error.foo.hour.required"))
+        Seq(ValidationError(Seq("subfieldFocus=hour", "error.foo.hour.required")))
       )
       validate(("", "59")) shouldBe Invalid(
-        Seq(ValidationError("error.foo.hour.required"))
+        Seq(ValidationError(Seq("subfieldFocus=hour", "error.foo.hour.required")))
       )
       validate(("24", "")) shouldBe Invalid(
         Seq(
-          ValidationError("error.foo.hour.invalid-value"),
-          ValidationError("error.foo.minutes.required")
+          ValidationError(Seq("subfieldFocus=hour", "error.foo.hour.invalid-value")),
+          ValidationError(Seq("subfieldFocus=minutes", "error.foo.minutes.required"))
         )
       )
       validate(("25", "60")) shouldBe Invalid(
         Seq(
-          ValidationError("error.foo.hour.invalid-value"),
-          ValidationError("error.foo.minutes.invalid-value")
+          ValidationError(Seq("subfieldFocus=hour", "error.foo.hour.invalid-value")),
+          ValidationError(Seq("subfieldFocus=minutes", "error.foo.minutes.invalid-value"))
         )
       )
       validate(("0a", "b0")) shouldBe Invalid(
         Seq(
-          ValidationError("error.foo.hour.invalid-digits"),
-          ValidationError("error.foo.minutes.invalid-digits")
+          ValidationError(Seq("subfieldFocus=hour", "error.foo.hour.invalid-digits")),
+          ValidationError(Seq("subfieldFocus=minutes", "error.foo.minutes.invalid-digits"))
         )
       )
     }
@@ -120,30 +120,30 @@ class Time24FieldHelperSpec extends UnitSpec with FormMappingMatchers {
       validate(("12", "00")) shouldBe Valid
       validate(("", "")) shouldBe Valid
       validate(("12", "")) shouldBe Invalid(
-        Seq(ValidationError("error.foo.minutes.required"))
+        Seq(ValidationError(Seq("subfieldFocus=minutes", "error.foo.minutes.required")))
       )
       validate(("", "59")) shouldBe Invalid(
-        Seq(ValidationError("error.foo.hour.required"))
+        Seq(ValidationError(Seq("subfieldFocus=hour", "error.foo.hour.required")))
       )
       validate(("", "59")) shouldBe Invalid(
-        Seq(ValidationError("error.foo.hour.required"))
+        Seq(ValidationError(Seq("subfieldFocus=hour", "error.foo.hour.required")))
       )
       validate(("24", "")) shouldBe Invalid(
         Seq(
-          ValidationError("error.foo.hour.invalid-value"),
-          ValidationError("error.foo.minutes.required")
+          ValidationError(Seq("subfieldFocus=hour", "error.foo.hour.invalid-value")),
+          ValidationError(Seq("subfieldFocus=minutes", "error.foo.minutes.required"))
         )
       )
       validate(("25", "60")) shouldBe Invalid(
         Seq(
-          ValidationError("error.foo.hour.invalid-value"),
-          ValidationError("error.foo.minutes.invalid-value")
+          ValidationError(Seq("subfieldFocus=hour", "error.foo.hour.invalid-value")),
+          ValidationError(Seq("subfieldFocus=minutes", "error.foo.minutes.invalid-value"))
         )
       )
       validate(("0a", "b0")) shouldBe Invalid(
         Seq(
-          ValidationError("error.foo.hour.invalid-digits"),
-          ValidationError("error.foo.minutes.invalid-digits")
+          ValidationError(Seq("subfieldFocus=hour", "error.foo.hour.invalid-digits")),
+          ValidationError(Seq("subfieldFocus=minutes", "error.foo.minutes.invalid-digits"))
         )
       )
     }

--- a/test/uk/gov/hmrc/traderservices/controllers/Time24FieldHelperSpec.scala
+++ b/test/uk/gov/hmrc/traderservices/controllers/Time24FieldHelperSpec.scala
@@ -84,7 +84,6 @@ class Time24FieldHelperSpec extends UnitSpec with FormMappingMatchers {
       validate(("12", "00")) shouldBe Valid
       validate(("12", "00")) shouldBe Valid
       validate(("", "")) shouldBe Invalid(ValidationError(Seq("subfieldFocus=hour", "error.foo.all.required")))
-      validate(("", "")) shouldBe Invalid(Seq(ValidationError(Seq("subfieldFocus=hour", "error.foo.all.required"))))
       validate(("12", "")) shouldBe Invalid(
         Seq(ValidationError(Seq("subfieldFocus=minutes", "error.foo.minutes.required")))
       )

--- a/test/uk/gov/hmrc/traderservices/controllers/VesselDetailsFormSpec.scala
+++ b/test/uk/gov/hmrc/traderservices/controllers/VesselDetailsFormSpec.scala
@@ -76,7 +76,9 @@ class VesselDetailsFormSpec extends UnitSpec with FormMatchers {
           .updated("dateOfArrival.month", "")
           .updated("dateOfArrival.day", "")
       form.bind(input).value shouldBe None
-      form.bind(input).errors should haveOnlyErrors(FormError("dateOfArrival", "error.dateOfArrival.all.required"))
+      form.bind(input).errors should haveOnlyErrors(
+        FormError("dateOfArrival", Seq("subfieldFocus=day", "error.dateOfArrival.all.required"))
+      )
     }
 
     "report an error when dateOfArrival is partially missing" in {
@@ -85,8 +87,8 @@ class VesselDetailsFormSpec extends UnitSpec with FormMatchers {
         .updated("dateOfArrival.month", "")
       form.bind(input).value shouldBe None
       form.bind(input).errors should haveOnlyErrors(
-        FormError("dateOfArrival", "error.dateOfArrival.year.required"),
-        FormError("dateOfArrival", "error.dateOfArrival.month.required")
+        FormError("dateOfArrival", Seq("subfieldFocus=year", "error.dateOfArrival.year.required")),
+        FormError("dateOfArrival", Seq("subfieldFocus=month", "error.dateOfArrival.month.required"))
       )
     }
 
@@ -96,8 +98,7 @@ class VesselDetailsFormSpec extends UnitSpec with FormMatchers {
         .updated("dateOfArrival.month", "13")
       form.bind(input).value shouldBe None
       form.bind(input).errors should haveOnlyErrors(
-        FormError("dateOfArrival", "error.dateOfArrival.year.invalid-digits"),
-        FormError("dateOfArrival", "error.dateOfArrival.month.invalid-value")
+        FormError("dateOfArrival", Seq("subfieldFocus=month", "error.dateOfArrival.all.invalid-value"))
       )
     }
 
@@ -107,7 +108,7 @@ class VesselDetailsFormSpec extends UnitSpec with FormMatchers {
         .updated("timeOfArrival.minutes", "")
       form.bind(input).value shouldBe None
       form.bind(input).errors should haveOnlyErrors(
-        FormError("timeOfArrival", "error.timeOfArrival.all.required")
+        FormError("timeOfArrival", Seq("subfieldFocus=hour", "error.timeOfArrival.all.required"))
       )
     }
 
@@ -117,7 +118,7 @@ class VesselDetailsFormSpec extends UnitSpec with FormMatchers {
         .updated("timeOfArrival.minutes", "")
       form.bind(input).value shouldBe None
       form.bind(input).errors should haveOnlyErrors(
-        FormError("timeOfArrival", "error.timeOfArrival.all.required")
+        FormError("timeOfArrival", Seq("subfieldFocus=hour", "error.timeOfArrival.all.required"))
       )
     }
 
@@ -127,8 +128,8 @@ class VesselDetailsFormSpec extends UnitSpec with FormMatchers {
         .updated("timeOfArrival.minutes", "60")
       form.bind(input).value shouldBe None
       form.bind(input).errors should haveOnlyErrors(
-        FormError("timeOfArrival", "error.timeOfArrival.hour.invalid-value"),
-        FormError("timeOfArrival", "error.timeOfArrival.minutes.invalid-value")
+        FormError("timeOfArrival", Seq("subfieldFocus=hour", "error.timeOfArrival.hour.invalid-value")),
+        FormError("timeOfArrival", Seq("subfieldFocus=minutes", "error.timeOfArrival.minutes.invalid-value"))
       )
     }
 
@@ -136,7 +137,7 @@ class VesselDetailsFormSpec extends UnitSpec with FormMatchers {
       val input = formInputFor(dateTime.minusMonths(6).minusDays(2))
       form.bind(input).value shouldBe None
       form.bind(input).errors should haveOnlyErrors(
-        FormError("dateOfArrival", "error.dateOfArrival.all.invalid-value-range")
+        FormError("dateOfArrival", Seq("subfieldFocus=day", "error.dateOfArrival.all.invalid-value-range"))
       )
     }
 
@@ -144,7 +145,7 @@ class VesselDetailsFormSpec extends UnitSpec with FormMatchers {
       val input = formInputFor(dateTime.plusMonths(6).plusDays(1))
       form.bind(input).value shouldBe None
       form.bind(input).errors should haveOnlyErrors(
-        FormError("dateOfArrival", "error.dateOfArrival.all.invalid-value-range")
+        FormError("dateOfArrival", Seq("subfieldFocus=day", "error.dateOfArrival.all.invalid-value-range"))
       )
     }
   }
@@ -190,8 +191,8 @@ class VesselDetailsFormSpec extends UnitSpec with FormMatchers {
         .updated("dateOfArrival.month", "")
       form.bind(input).value shouldBe None
       form.bind(input).errors should haveOnlyErrors(
-        FormError("dateOfArrival", "error.dateOfArrival.year.required"),
-        FormError("dateOfArrival", "error.dateOfArrival.month.required")
+        FormError("dateOfArrival", Seq("subfieldFocus=year", "error.dateOfArrival.year.required")),
+        FormError("dateOfArrival", Seq("subfieldFocus=month", "error.dateOfArrival.month.required"))
       )
     }
 
@@ -201,8 +202,7 @@ class VesselDetailsFormSpec extends UnitSpec with FormMatchers {
         .updated("dateOfArrival.month", "13")
       form.bind(input).value shouldBe None
       form.bind(input).errors should haveOnlyErrors(
-        FormError("dateOfArrival", "error.dateOfArrival.year.invalid-digits"),
-        FormError("dateOfArrival", "error.dateOfArrival.month.invalid-value")
+        FormError("dateOfArrival", Seq("subfieldFocus=month", "error.dateOfArrival.all.invalid-value"))
       )
     }
 
@@ -230,8 +230,8 @@ class VesselDetailsFormSpec extends UnitSpec with FormMatchers {
         .updated("timeOfArrival.minutes", "60")
       form.bind(input).value shouldBe None
       form.bind(input).errors should haveOnlyErrors(
-        FormError("timeOfArrival", "error.timeOfArrival.hour.invalid-value"),
-        FormError("timeOfArrival", "error.timeOfArrival.minutes.invalid-value")
+        FormError("timeOfArrival", Seq("subfieldFocus=hour", "error.timeOfArrival.hour.invalid-value")),
+        FormError("timeOfArrival", Seq("subfieldFocus=minutes", "error.timeOfArrival.minutes.invalid-value"))
       )
     }
 
@@ -239,7 +239,7 @@ class VesselDetailsFormSpec extends UnitSpec with FormMatchers {
       val input = formInputFor(dateTime.minusMonths(6).minusDays(2))
       form.bind(input).value shouldBe None
       form.bind(input).errors should haveOnlyErrors(
-        FormError("dateOfArrival", "error.dateOfArrival.all.invalid-value-range")
+        FormError("dateOfArrival", Seq("subfieldFocus=day", "error.dateOfArrival.all.invalid-value-range"))
       )
     }
 
@@ -247,7 +247,7 @@ class VesselDetailsFormSpec extends UnitSpec with FormMatchers {
       val input = formInputFor(dateTime.plusMonths(6).plusDays(1))
       form.bind(input).value shouldBe None
       form.bind(input).errors should haveOnlyErrors(
-        FormError("dateOfArrival", "error.dateOfArrival.all.invalid-value-range")
+        FormError("dateOfArrival", Seq("subfieldFocus=day", "error.dateOfArrival.all.invalid-value-range"))
       )
     }
   }

--- a/test/uk/gov/hmrc/traderservices/controllers/VesselDetailsFormSpec.scala
+++ b/test/uk/gov/hmrc/traderservices/controllers/VesselDetailsFormSpec.scala
@@ -112,16 +112,6 @@ class VesselDetailsFormSpec extends UnitSpec with FormMatchers {
       )
     }
 
-    "report an error when timeOfArrival is partially missing" in {
-      val input = formInput
-        .updated("timeOfArrival.hour", "")
-        .updated("timeOfArrival.minutes", "")
-      form.bind(input).value shouldBe None
-      form.bind(input).errors should haveOnlyErrors(
-        FormError("timeOfArrival", Seq("subfieldFocus=hour", "error.timeOfArrival.all.required"))
-      )
-    }
-
     "report an error when timeOfArrival is invalid" in {
       val input = formInput
         .updated("timeOfArrival.hour", "25")

--- a/test/uk/gov/hmrc/traderservices/support/FormMatchers.scala
+++ b/test/uk/gov/hmrc/traderservices/support/FormMatchers.scala
@@ -24,7 +24,7 @@ trait FormMatchers {
   def haveError(expectedError: FormError): Matcher[Seq[FormError]] =
     new Matcher[Seq[FormError]] {
       override def apply(errors: Seq[FormError]): MatchResult =
-        if (errors.find(_.key == expectedError.key).exists(_.message == expectedError.message))
+        if (errors.find(_.key == expectedError.key).exists(_.messages == expectedError.messages))
           MatchResult(true, "", s"")
         else
           MatchResult(
@@ -37,8 +37,8 @@ trait FormMatchers {
   def haveOnlyErrors(expectedErrors: FormError*): Matcher[Seq[FormError]] =
     new Matcher[Seq[FormError]] {
       override def apply(errors: Seq[FormError]): MatchResult = {
-        val found = errors.map(e => (e.key, e.message)).toSet
-        val expected = expectedErrors.map(e => (e.key, e.message)).toSet
+        val found = errors.map(e => (e.key, e.messages)).toSet
+        val expected = expectedErrors.map(e => (e.key, e.messages)).toSet
         val unexpected = found.diff(expected)
         val unfulfilled = expected.diff(found)
         if (found == expected)
@@ -59,7 +59,7 @@ trait FormMatchers {
   def haveOnlyError(expectedError: FormError): Matcher[Seq[FormError]] =
     new Matcher[Seq[FormError]] {
       override def apply(errors: Seq[FormError]): MatchResult =
-        if (errors.size == 1 && errors.find(_.key == expectedError.key).exists(_.message == expectedError.message))
+        if (errors.size == 1 && errors.find(_.key == expectedError.key).exists(_.messages == expectedError.messages))
           MatchResult(true, "", s"")
         else
           MatchResult(


### PR DESCRIPTION
This PR:
- introduces a more precise error linking for multi-input fields, like date or time,
- reimplements grouping of `.invalid-*` errors to include all of them, not only `.invalid-values`