### PR TITLE
[AO] update and cleanup dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,25 +17,23 @@ lazy val scoverageSettings = {
 lazy val compileDeps = Seq(
   ws,
   "uk.gov.hmrc"                  %% "bootstrap-frontend-play-26" % "2.25.0",
-  "uk.gov.hmrc"                  %% "auth-client"                % "3.1.0-play-26",
-  "uk.gov.hmrc"                  %% "play-partials"              % "6.11.0-play-26",
-  "uk.gov.hmrc"                  %% "play-fsm"                   % "0.69.0-play-26",
+  "uk.gov.hmrc"                  %% "auth-client"                % "3.2.0-play-26",
+  "uk.gov.hmrc"                  %% "play-fsm"                   % "0.70.0-play-26",
   "uk.gov.hmrc"                  %% "domain"                     % "5.10.0-play-26",
-  "uk.gov.hmrc"                  %% "mongo-caching"              % "6.15.0-play-26",
+  "uk.gov.hmrc"                  %% "mongo-caching"              % "6.16.0-play-26",
   "uk.gov.hmrc"                  %% "json-encryption"            % "4.8.0-play-26",
-  "uk.gov.hmrc"                  %% "play-frontend-govuk"        % "0.53.0-play-26",
-  "uk.gov.hmrc"                  %% "play-frontend-hmrc"         % "0.26.0-play-26",
-  "com.googlecode.libphonenumber" % "libphonenumber"             % "8.12.11",
+  "uk.gov.hmrc"                  %% "play-frontend-govuk"        % "0.56.0-play-26",
+  "uk.gov.hmrc"                  %% "play-frontend-hmrc"         % "0.29.0-play-26",
+  "com.googlecode.libphonenumber" % "libphonenumber"             % "8.12.14",
   "com.sun.mail"                  % "javax.mail"                 % "1.6.2"
 )
 
 def testDeps(scope: String) =
   Seq(
-    "uk.gov.hmrc"            %% "hmrctest"           % "3.9.0-play-26" % scope,
-    "org.scalatest"          %% "scalatest"          % "3.0.9"         % scope,
-    "org.mockito"             % "mockito-core"       % "3.1.0"         % scope,
-    "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.3"         % scope,
-    "com.github.tomakehurst"  % "wiremock"           % "2.27.2"        % scope
+    "org.scalatest"          %% "scalatest"          % "3.2.3"  % scope,
+    "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.3"  % scope,
+    "com.github.tomakehurst"  % "wiremock"           % "2.27.2" % scope,
+    "com.vladsch.flexmark"    % "flexmark-all"       % "0.36.8" % scope
   )
 
 val jettyVersion = "9.2.24.v20180105"
@@ -124,5 +122,3 @@ def oneForkedJvmPerTest(tests: Seq[TestDefinition]) =
   tests.map { test =>
     new Group(test.name, Seq(test), SubProcess(ForkOptions().withRunJVMOptions(Vector(s"-Dtest.name=${test.name}"))))
   }
-
-Compile / compile / logLevel := Level.Error

--- a/it/uk/gov/hmrc/traderservices/support/BaseISpec.scala
+++ b/it/uk/gov/hmrc/traderservices/support/BaseISpec.scala
@@ -12,7 +12,7 @@ import uk.gov.hmrc.traderservices.stubs.{AuthStubs, DataStreamStubs}
 import uk.gov.hmrc.traderservices.wiring.AppConfig
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.HeaderCarrierConverter
-import uk.gov.hmrc.play.test.UnitSpec
+import uk.gov.hmrc.traderservices.support.UnitSpec
 
 abstract class BaseISpec
     extends UnitSpec with WireMockSupport with AuthStubs with DataStreamStubs with MetricsTestSupport {

--- a/it/uk/gov/hmrc/traderservices/support/MetricsTestSupport.scala
+++ b/it/uk/gov/hmrc/traderservices/support/MetricsTestSupport.scala
@@ -2,10 +2,11 @@ package uk.gov.hmrc.traderservices.support
 
 import com.codahale.metrics.MetricRegistry
 import com.kenshoo.play.metrics.Metrics
-import org.scalatest.{Matchers, Suite}
+import org.scalatest.Suite
 import play.api.Application
 
 import scala.collection.JavaConverters
+import org.scalatest.matchers.should.Matchers
 
 trait MetricsTestSupport {
   self: Suite with Matchers =>

--- a/it/uk/gov/hmrc/traderservices/support/NonAuthPageISpec.scala
+++ b/it/uk/gov/hmrc/traderservices/support/NonAuthPageISpec.scala
@@ -8,7 +8,6 @@ import play.api.{Application, Configuration}
 import play.api.i18n.{Lang, Messages, MessagesApi}
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.ws.WSClient
-import uk.gov.hmrc.play.test.UnitSpec
 
 abstract class NonAuthPageISpec(config: (String, Any)*) extends ServerISpec with GuiceOneServerPerSuite {
 

--- a/it/uk/gov/hmrc/traderservices/support/Port.scala
+++ b/it/uk/gov/hmrc/traderservices/support/Port.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.traderservices.support
+
+import annotation.tailrec
+import java.net.ServerSocket
+import play.api.Logger._
+
+object Port {
+  val rnd = new scala.util.Random
+  val range = 8000 to 39999
+  val usedPorts = List[Int]()
+
+  @tailrec
+  def randomAvailable: Int =
+    range(rnd.nextInt(range length)) match {
+      case 8080 => randomAvailable
+      case 8090 => randomAvailable
+      case p: Int =>
+        available(p) match {
+          case false =>
+            debug(s"Port $p is in use, trying another")
+            randomAvailable
+          case true =>
+            debug("Taking port : " + p)
+            usedPorts :+ p
+            p
+        }
+    }
+
+  private def available(p: Int): Boolean = {
+    var socket: ServerSocket = null
+    try if (!usedPorts.contains(p)) {
+      socket = new ServerSocket(p)
+      socket.setReuseAddress(true)
+      true
+    } else
+      false
+    catch {
+      case t: Throwable => false
+    } finally if (socket != null) socket.close()
+  }
+}

--- a/it/uk/gov/hmrc/traderservices/support/UnitSpec.scala
+++ b/it/uk/gov/hmrc/traderservices/support/UnitSpec.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.traderservices.support
+
+import java.nio.charset.Charset
+
+import akka.stream.Materializer
+import akka.util.ByteString
+import play.api.libs.json.{JsValue, Json}
+import play.api.mvc.Result
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.language.implicitConversions
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.OptionValues
+import org.scalatest.wordspec.AnyWordSpec
+
+trait UnitSpec extends AnyWordSpec with Matchers with OptionValues {
+
+  import scala.concurrent.duration._
+  import scala.concurrent.{Await, Future}
+
+  implicit val defaultTimeout: FiniteDuration = 5 seconds
+
+  implicit def extractAwait[A](future: Future[A]): A = await[A](future)
+
+  def await[A](future: Future[A])(implicit timeout: Duration): A = Await.result(future, timeout)
+
+  // Convenience to avoid having to wrap andThen() parameters in Future.successful
+  implicit def liftFuture[A](v: A): Future[A] = Future.successful(v)
+
+  def status(of: Result): Int = of.header.status
+
+  def status(of: Future[Result])(implicit timeout: Duration): Int = status(Await.result(of, timeout))
+
+  def jsonBodyOf(result: Result)(implicit mat: Materializer): JsValue =
+    Json.parse(bodyOf(result))
+
+  def jsonBodyOf(resultF: Future[Result])(implicit mat: Materializer): Future[JsValue] =
+    resultF.map(jsonBodyOf)
+
+  def bodyOf(result: Result)(implicit mat: Materializer): String = {
+    val bodyBytes: ByteString = await(result.body.consumeData)
+    // We use the default charset to preserve the behaviour of a previous
+    // version of this code, which used new String(Array[Byte]).
+    // If the fact that the previous version used the default charset was an
+    // accident then it may be better to decode in UTF-8 or the charset
+    // specified by the result's headers.
+    bodyBytes.decodeString(Charset.defaultCharset().name)
+  }
+
+  def bodyOf(resultF: Future[Result])(implicit mat: Materializer): Future[String] =
+    resultF.map(bodyOf)
+}

--- a/it/uk/gov/hmrc/traderservices/support/WireMockSupport.scala
+++ b/it/uk/gov/hmrc/traderservices/support/WireMockSupport.scala
@@ -7,7 +7,6 @@ import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration._
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Suite}
-import uk.gov.hmrc.play.it.Port
 
 case class WireMockBaseUrl(value: URL)
 

--- a/test/uk/gov/hmrc/traderservices/controllers/AmendCaseFormsSpec.scala
+++ b/test/uk/gov/hmrc/traderservices/controllers/AmendCaseFormsSpec.scala
@@ -16,10 +16,10 @@
 
 package uk.gov.hmrc.traderservices.controllers
 
-import uk.gov.hmrc.play.test.UnitSpec
 import uk.gov.hmrc.traderservices.models.TypeOfAmendment
 import uk.gov.hmrc.traderservices.support.FormValidator
 import scala.util.Random
+import uk.gov.hmrc.traderservices.support.UnitSpec
 
 class AmendCaseFormsSpec extends UnitSpec with FormValidator {
 

--- a/test/uk/gov/hmrc/traderservices/controllers/ContactFieldHelperSpec.scala
+++ b/test/uk/gov/hmrc/traderservices/controllers/ContactFieldHelperSpec.scala
@@ -20,7 +20,7 @@ import java.time.LocalDate
 import java.time.temporal.ChronoField
 
 import play.api.data.FormError
-import uk.gov.hmrc.play.test.UnitSpec
+import uk.gov.hmrc.traderservices.support.UnitSpec
 import uk.gov.hmrc.traderservices.models.{DeclarationDetails, EPU, EntryNumber}
 import uk.gov.hmrc.traderservices.support.FormMatchers
 

--- a/test/uk/gov/hmrc/traderservices/controllers/DateFieldHelperSpec.scala
+++ b/test/uk/gov/hmrc/traderservices/controllers/DateFieldHelperSpec.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.traderservices.controllers
 import java.time.LocalDate
 
 import uk.gov.hmrc.traderservices.controllers.DateFieldHelper._
-import uk.gov.hmrc.play.test.UnitSpec
+import uk.gov.hmrc.traderservices.support.UnitSpec
 import uk.gov.hmrc.traderservices.support.FormMappingMatchers
 
 class DateFieldHelperSpec extends UnitSpec with FormMappingMatchers {

--- a/test/uk/gov/hmrc/traderservices/controllers/DeclarationDetailsFormSpec.scala
+++ b/test/uk/gov/hmrc/traderservices/controllers/DeclarationDetailsFormSpec.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.traderservices.controllers
 import java.time.LocalDate
 
 import play.api.data.FormError
-import uk.gov.hmrc.play.test.UnitSpec
+import uk.gov.hmrc.traderservices.support.UnitSpec
 import uk.gov.hmrc.traderservices.models.{DeclarationDetails, EPU, EntryNumber}
 import uk.gov.hmrc.traderservices.support.FormMatchers
 import java.time.temporal.ChronoField

--- a/test/uk/gov/hmrc/traderservices/controllers/ExportQuestionsFormSpec.scala
+++ b/test/uk/gov/hmrc/traderservices/controllers/ExportQuestionsFormSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.traderservices.controllers
 
-import uk.gov.hmrc.play.test.UnitSpec
+import uk.gov.hmrc.traderservices.support.UnitSpec
 import uk.gov.hmrc.traderservices.models.{ExportContactInfo, ExportFreightType, ExportPriorityGoods, ExportRequestType, ExportRouteType}
 import uk.gov.hmrc.traderservices.support.FormValidator
 

--- a/test/uk/gov/hmrc/traderservices/controllers/FormFieldMappingsSpec.scala
+++ b/test/uk/gov/hmrc/traderservices/controllers/FormFieldMappingsSpec.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.traderservices.controllers
 
 import java.time.LocalDate
 
-import uk.gov.hmrc.play.test.UnitSpec
+import uk.gov.hmrc.traderservices.support.UnitSpec
 import uk.gov.hmrc.traderservices.controllers.FormFieldMappings._
 import uk.gov.hmrc.traderservices.models.{EPU, EntryNumber, ExportFreightType, ExportPriorityGoods, ExportRequestType, ExportRouteType, ImportFreightType, ImportPriorityGoods, ImportRequestType, ImportRouteType}
 import uk.gov.hmrc.traderservices.support.FormMappingMatchers

--- a/test/uk/gov/hmrc/traderservices/controllers/ImportQuestionsFormSpec.scala
+++ b/test/uk/gov/hmrc/traderservices/controllers/ImportQuestionsFormSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.traderservices.controllers
 
-import uk.gov.hmrc.play.test.UnitSpec
+import uk.gov.hmrc.traderservices.support.UnitSpec
 import uk.gov.hmrc.traderservices.models.{ImportContactInfo, ImportFreightType, ImportPriorityGoods, ImportRequestType, ImportRouteType}
 import uk.gov.hmrc.traderservices.support.FormValidator
 

--- a/test/uk/gov/hmrc/traderservices/controllers/Time12FieldHelperSpec.scala
+++ b/test/uk/gov/hmrc/traderservices/controllers/Time12FieldHelperSpec.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.traderservices.controllers
 import java.time.LocalTime
 
 import uk.gov.hmrc.traderservices.controllers.Time12FieldHelper._
-import uk.gov.hmrc.play.test.UnitSpec
+import uk.gov.hmrc.traderservices.support.UnitSpec
 import java.time.LocalTime
 import uk.gov.hmrc.traderservices.support.FormMappingMatchers
 import play.api.data.validation.Valid

--- a/test/uk/gov/hmrc/traderservices/controllers/Time24FieldHelperSpec.scala
+++ b/test/uk/gov/hmrc/traderservices/controllers/Time24FieldHelperSpec.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.traderservices.controllers
 import java.time.LocalTime
 
 import uk.gov.hmrc.traderservices.controllers.Time24FieldHelper._
-import uk.gov.hmrc.play.test.UnitSpec
+import uk.gov.hmrc.traderservices.support.UnitSpec
 import java.time.LocalTime
 import uk.gov.hmrc.traderservices.support.FormMappingMatchers
 import play.api.data.validation.Valid

--- a/test/uk/gov/hmrc/traderservices/controllers/VesselDetailsFormSpec.scala
+++ b/test/uk/gov/hmrc/traderservices/controllers/VesselDetailsFormSpec.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.traderservices.controllers
 
 import play.api.data.FormError
-import uk.gov.hmrc.play.test.UnitSpec
+import uk.gov.hmrc.traderservices.support.UnitSpec
 import uk.gov.hmrc.traderservices.models.VesselDetails
 import uk.gov.hmrc.traderservices.support.FormMatchers
 import java.time.LocalDateTime

--- a/test/uk/gov/hmrc/traderservices/journey/AmendCaseJourneyModelSpec.scala
+++ b/test/uk/gov/hmrc/traderservices/journey/AmendCaseJourneyModelSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.traderservices.journey
 
-import uk.gov.hmrc.play.test.UnitSpec
+import uk.gov.hmrc.traderservices.support.UnitSpec
 import uk.gov.hmrc.traderservices.journeys.AmendCaseJourneyModel.State._
 import uk.gov.hmrc.traderservices.journeys.AmendCaseJourneyModel.FileUploadState._
 import uk.gov.hmrc.traderservices.journeys.AmendCaseJourneyModel.Transitions._

--- a/test/uk/gov/hmrc/traderservices/journey/AmendCaseJourneyStateFormatsSpec.scala
+++ b/test/uk/gov/hmrc/traderservices/journey/AmendCaseJourneyStateFormatsSpec.scala
@@ -21,7 +21,7 @@ import uk.gov.hmrc.traderservices.journeys.AmendCaseJourneyModel.State
 import uk.gov.hmrc.traderservices.journeys.AmendCaseJourneyModel.FileUploadState
 import uk.gov.hmrc.traderservices.journeys.AmendCaseJourneyStateFormats
 import uk.gov.hmrc.traderservices.models._
-import uk.gov.hmrc.play.test.UnitSpec
+import uk.gov.hmrc.traderservices.support.UnitSpec
 import uk.gov.hmrc.traderservices.support.JsonFormatTest
 import java.time.ZonedDateTime
 import scala.util.Random

--- a/test/uk/gov/hmrc/traderservices/journey/CreateCaseJourneyModelSpec.scala
+++ b/test/uk/gov/hmrc/traderservices/journey/CreateCaseJourneyModelSpec.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.traderservices.journey
 
 import java.time.LocalDate
 
-import uk.gov.hmrc.play.test.UnitSpec
+import uk.gov.hmrc.traderservices.support.UnitSpec
 import uk.gov.hmrc.traderservices.journeys.CreateCaseJourneyModel.State._
 import uk.gov.hmrc.traderservices.journeys.CreateCaseJourneyModel.FileUploadState._
 import uk.gov.hmrc.traderservices.journeys.CreateCaseJourneyModel.Transitions._

--- a/test/uk/gov/hmrc/traderservices/journey/CreateCaseJourneyStateFormatsSpec.scala
+++ b/test/uk/gov/hmrc/traderservices/journey/CreateCaseJourneyStateFormatsSpec.scala
@@ -23,7 +23,7 @@ import uk.gov.hmrc.traderservices.journeys.CreateCaseJourneyModel.State
 import uk.gov.hmrc.traderservices.journeys.CreateCaseJourneyModel.FileUploadState
 import uk.gov.hmrc.traderservices.journeys.CreateCaseJourneyStateFormats
 import uk.gov.hmrc.traderservices.models._
-import uk.gov.hmrc.play.test.UnitSpec
+import uk.gov.hmrc.traderservices.support.UnitSpec
 import uk.gov.hmrc.traderservices.support.JsonFormatTest
 import java.time.LocalTime
 import java.time.ZonedDateTime

--- a/test/uk/gov/hmrc/traderservices/model/AmendCaseFormatsSpec.scala
+++ b/test/uk/gov/hmrc/traderservices/model/AmendCaseFormatsSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.traderservices.model
 
-import uk.gov.hmrc.play.test.UnitSpec
+import uk.gov.hmrc.traderservices.support.UnitSpec
 import uk.gov.hmrc.traderservices.models._
 import uk.gov.hmrc.traderservices.support.JsonFormatTest
 

--- a/test/uk/gov/hmrc/traderservices/model/DeclarationDetailsSpec.scala
+++ b/test/uk/gov/hmrc/traderservices/model/DeclarationDetailsSpec.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.traderservices.model
 
 import java.time.LocalDate
 
-import uk.gov.hmrc.play.test.UnitSpec
+import uk.gov.hmrc.traderservices.support.UnitSpec
 import uk.gov.hmrc.traderservices.models._
 
 class DeclarationDetailsSpec extends UnitSpec with TestData {

--- a/test/uk/gov/hmrc/traderservices/model/ExportQuestionsFormatSpec.scala
+++ b/test/uk/gov/hmrc/traderservices/model/ExportQuestionsFormatSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.traderservices.model
 
-import uk.gov.hmrc.play.test.UnitSpec
+import uk.gov.hmrc.traderservices.support.UnitSpec
 import uk.gov.hmrc.traderservices.models._
 import uk.gov.hmrc.traderservices.support.JsonFormatTest
 

--- a/test/uk/gov/hmrc/traderservices/model/FileUploadFailureFormatSpec.scala
+++ b/test/uk/gov/hmrc/traderservices/model/FileUploadFailureFormatSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.traderservices.model
 
-import uk.gov.hmrc.play.test.UnitSpec
+import uk.gov.hmrc.traderservices.support.UnitSpec
 import uk.gov.hmrc.traderservices.models._
 import uk.gov.hmrc.traderservices.support.JsonFormatTest
 

--- a/test/uk/gov/hmrc/traderservices/model/ImportQuestionsFormatSpec.scala
+++ b/test/uk/gov/hmrc/traderservices/model/ImportQuestionsFormatSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.traderservices.model
 
-import uk.gov.hmrc.play.test.UnitSpec
+import uk.gov.hmrc.traderservices.support.UnitSpec
 import uk.gov.hmrc.traderservices.models._
 import uk.gov.hmrc.traderservices.support.JsonFormatTest
 

--- a/test/uk/gov/hmrc/traderservices/model/UpscanNotificationFormatSpec.scala
+++ b/test/uk/gov/hmrc/traderservices/model/UpscanNotificationFormatSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.traderservices.model
 
-import uk.gov.hmrc.play.test.UnitSpec
+import uk.gov.hmrc.traderservices.support.UnitSpec
 import uk.gov.hmrc.traderservices.models._
 import uk.gov.hmrc.traderservices.support.JsonFormatTest
 import java.time.ZonedDateTime

--- a/test/uk/gov/hmrc/traderservices/support/CallOpsSpec.scala
+++ b/test/uk/gov/hmrc/traderservices/support/CallOpsSpec.scala
@@ -21,7 +21,6 @@ import java.io.File
 import com.typesafe.config._
 import play.api.{Configuration, Environment, Mode}
 import uk.gov.hmrc.traderservices.support.CallOps.localFriendlyUrl
-import uk.gov.hmrc.play.test.UnitSpec
 
 class CallOpsSpec extends UnitSpec {
 

--- a/test/uk/gov/hmrc/traderservices/support/FormValidator.scala
+++ b/test/uk/gov/hmrc/traderservices/support/FormValidator.scala
@@ -18,8 +18,8 @@ package uk.gov.hmrc.traderservices.support
 
 import play.api.data.Form
 import play.api.data.FormError
-import org.scalatest.Matchers
 import org.scalatest.OptionValues
+import org.scalatest.matchers.should.Matchers
 
 trait FormValidator extends FormMatchers {
   self: Matchers with OptionValues =>

--- a/test/uk/gov/hmrc/traderservices/support/JsonFormatTest.scala
+++ b/test/uk/gov/hmrc/traderservices/support/JsonFormatTest.scala
@@ -17,11 +17,11 @@
 package uk.gov.hmrc.traderservices.support
 
 import org.scalatest.Assertion
-import org.scalatest.Matchers._
 import play.api.libs.json.{Format, Json}
 import org.scalatest.Informer
+import org.scalatest.matchers.should.Matchers
 
-abstract class JsonFormatTest[A: Format](info: Informer) {
+abstract class JsonFormatTest[A: Format](info: Informer) extends Matchers {
 
   case class TestEntity(entity: A)
   implicit val testFormat: Format[TestEntity] = Json.format[TestEntity]

--- a/test/uk/gov/hmrc/traderservices/support/UnitSpec.scala
+++ b/test/uk/gov/hmrc/traderservices/support/UnitSpec.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.traderservices.support
+
+import java.nio.charset.Charset
+
+import akka.stream.Materializer
+import akka.util.ByteString
+import play.api.libs.json.{JsValue, Json}
+import play.api.mvc.Result
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.language.implicitConversions
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.OptionValues
+import org.scalatest.wordspec.AnyWordSpec
+
+trait UnitSpec extends AnyWordSpec with Matchers with OptionValues {
+
+  import scala.concurrent.duration._
+  import scala.concurrent.{Await, Future}
+
+  implicit val defaultTimeout: FiniteDuration = 5 seconds
+
+  implicit def extractAwait[A](future: Future[A]): A = await[A](future)
+
+  def await[A](future: Future[A])(implicit timeout: Duration): A = Await.result(future, timeout)
+
+  // Convenience to avoid having to wrap andThen() parameters in Future.successful
+  implicit def liftFuture[A](v: A): Future[A] = Future.successful(v)
+
+  def status(of: Result): Int = of.header.status
+
+  def status(of: Future[Result])(implicit timeout: Duration): Int = status(Await.result(of, timeout))
+
+  def jsonBodyOf(result: Result)(implicit mat: Materializer): JsValue =
+    Json.parse(bodyOf(result))
+
+  def jsonBodyOf(resultF: Future[Result])(implicit mat: Materializer): Future[JsValue] =
+    resultF.map(jsonBodyOf)
+
+  def bodyOf(result: Result)(implicit mat: Materializer): String = {
+    val bodyBytes: ByteString = await(result.body.consumeData)
+    // We use the default charset to preserve the behaviour of a previous
+    // version of this code, which used new String(Array[Byte]).
+    // If the fact that the previous version used the default charset was an
+    // accident then it may be better to decode in UTF-8 or the charset
+    // specified by the result's headers.
+    bodyBytes.decodeString(Charset.defaultCharset().name)
+  }
+
+  def bodyOf(resultF: Future[Result])(implicit mat: Materializer): Future[String] =
+    resultF.map(bodyOf)
+}


### PR DESCRIPTION
This PR removes some unused dependencies and upgrades the remaining ones.  

Most of the changes are the result of upgrading ` scalatest` to `3.2.3` from the long-outdated `3.0.9`, and the removal of deprecated `hmrctest` library. 