### PR TITLE
[DOR-203][AO] upload multiple files - server-side journey modifications

### DIFF
--- a/app/uk/gov/hmrc/traderservices/controllers/AmendCaseJourneyController.scala
+++ b/app/uk/gov/hmrc/traderservices/controllers/AmendCaseJourneyController.scala
@@ -622,7 +622,7 @@ object AmendCaseJourneyController {
   val UpscanUploadSuccessForm = Form[S3UploadSuccess](
     mapping(
       "key"    -> nonEmptyText,
-      "bucket" -> nonEmptyText
+      "bucket" -> optional(nonEmptyText)
     )(S3UploadSuccess.apply)(S3UploadSuccess.unapply)
   )
 

--- a/app/uk/gov/hmrc/traderservices/controllers/AmendCaseJourneyController.scala
+++ b/app/uk/gov/hmrc/traderservices/controllers/AmendCaseJourneyController.scala
@@ -189,13 +189,13 @@ class AmendCaseJourneyController @Inject() (
       expectedContentType = Some(appConfig.fileFormats.approvedFileTypes)
     )
 
-  // GET /add/upload-multiple-files
+  // GET /add/upload-files
   final val showUploadMultipleFiles: Action[AnyContent] =
     whenAuthorisedAsUser
       .apply(FileUploadTransitions.toUploadMultipleFiles)
       .redirectOrDisplayIf[FileUploadState.UploadMultipleFiles]
 
-  // PUT /add/upload-multiple-files/initialise/:uploadId
+  // PUT /add/upload-files/initialise/:uploadId
   final def initiateNextFileUpload(uploadId: String): Action[AnyContent] =
     whenAuthorisedAsUser
       .applyWithRequest { implicit request =>

--- a/app/uk/gov/hmrc/traderservices/controllers/AmendCaseJourneyController.scala
+++ b/app/uk/gov/hmrc/traderservices/controllers/AmendCaseJourneyController.scala
@@ -551,6 +551,7 @@ class AmendCaseJourneyController @Inject() (
   ): Result =
     state match {
       case s: FileUploadState => NoContent
+      case _                  => BadRequest
     }
 
   private def streamFileFromUspcan(

--- a/app/uk/gov/hmrc/traderservices/controllers/AmendCaseJourneyController.scala
+++ b/app/uk/gov/hmrc/traderservices/controllers/AmendCaseJourneyController.scala
@@ -195,7 +195,7 @@ class AmendCaseJourneyController @Inject() (
       .apply(FileUploadTransitions.toUploadMultipleFiles)
       .redirectOrDisplayIf[FileUploadState.UploadMultipleFiles]
 
-  // PUT /add/upload-multiple-files/initiate-next
+  // PUT /add/upload-multiple-files/initialise/:uploadId
   final def initiateNextFileUpload(uploadId: String): Action[AnyContent] =
     whenAuthorisedAsUser
       .applyWithRequest { implicit request =>

--- a/app/uk/gov/hmrc/traderservices/controllers/AmendCaseJourneyController.scala
+++ b/app/uk/gov/hmrc/traderservices/controllers/AmendCaseJourneyController.scala
@@ -115,7 +115,9 @@ class AmendCaseJourneyController @Inject() (
     whenAuthorisedAsUser
       .bindForm(TypeOfAmendmentForm)
       .applyWithRequest(implicit request =>
-        Transitions.submitedTypeOfAmendment(upscanRequest)(upscanInitiateConnector.initiate(_))
+        Transitions.submitedTypeOfAmendment(preferUploadMultipleFiles)(upscanRequest)(
+          upscanInitiateConnector.initiate(_)
+        )
       )
 
   // GET /add/write-response
@@ -129,7 +131,7 @@ class AmendCaseJourneyController @Inject() (
     whenAuthorisedAsUser
       .bindForm(ResponseTextForm)
       .applyWithRequest(implicit request =>
-        Transitions.submitedResponseText(upscanRequest)(upscanInitiateConnector.initiate(_))
+        Transitions.submitedResponseText(preferUploadMultipleFiles)(upscanRequest)(upscanInitiateConnector.initiate(_))
       )
 
   // GET 	/add/check-your-answers
@@ -480,12 +482,15 @@ class AmendCaseJourneyController @Inject() (
 
     }
 
-  private def backLinkFromSummary(model: AmendCaseModel): Call =
+  private def backLinkFromSummary(model: AmendCaseModel)(implicit rh: RequestHeader): Call =
     model.typeOfAmendment match {
       case Some(TypeOfAmendment.WriteResponse) =>
         controller.showEnterResponseText()
       case _ =>
-        controller.showFileUploaded()
+        if (preferUploadMultipleFiles)
+          controller.showUploadMultipleFiles
+        else
+          controller.showFileUploaded
     }
 
   private def backLinkFromFileUpload(model: AmendCaseModel): Call =

--- a/app/uk/gov/hmrc/traderservices/controllers/CreateCaseJourneyController.scala
+++ b/app/uk/gov/hmrc/traderservices/controllers/CreateCaseJourneyController.scala
@@ -401,7 +401,7 @@ class CreateCaseJourneyController @Inject() (
       .apply(FileUploadTransitions.toUploadMultipleFiles)
       .redirectOrDisplayIf[FileUploadState.UploadMultipleFiles]
 
-  // PUT /new/upload-multiple-files/initiate-next
+  // PUT /new/upload-multiple-files/initialise/:uploadId
   final def initiateNextFileUpload(uploadId: String): Action[AnyContent] =
     whenAuthorisedAsUser
       .applyWithRequest { implicit request =>

--- a/app/uk/gov/hmrc/traderservices/controllers/CreateCaseJourneyController.scala
+++ b/app/uk/gov/hmrc/traderservices/controllers/CreateCaseJourneyController.scala
@@ -961,9 +961,9 @@ class CreateCaseJourneyController @Inject() (
           case Some((reference, uploadRequest)) =>
             val json =
               Json.obj(
-                "reference"     -> reference,
-                "uploadId"      -> uploadId,
-                "uploadRequest" -> UploadRequest.formats.writes(uploadRequest)
+                "upscanReference" -> reference,
+                "uploadId"        -> uploadId,
+                "uploadRequest"   -> UploadRequest.formats.writes(uploadRequest)
               )
             Ok(json)
 

--- a/app/uk/gov/hmrc/traderservices/controllers/CreateCaseJourneyController.scala
+++ b/app/uk/gov/hmrc/traderservices/controllers/CreateCaseJourneyController.scala
@@ -215,7 +215,7 @@ class CreateCaseJourneyController @Inject() (
     whenAuthorisedAsUser
       .bindForm(ExportContactForm)
       .applyWithRequest(implicit request =>
-        Transitions.submittedExportQuestionsContactInfo(appConfig.uploadMultipleFilesFeature)(upscanRequest)(
+        Transitions.submittedExportQuestionsContactInfo(preferUploadMultipleFiles)(upscanRequest)(
           upscanInitiateConnector.initiate(_)
         )
       )
@@ -335,7 +335,7 @@ class CreateCaseJourneyController @Inject() (
     whenAuthorisedAsUser
       .bindForm(ImportContactForm)
       .applyWithRequest(implicit request =>
-        Transitions.submittedImportQuestionsContactInfo(appConfig.uploadMultipleFilesFeature)(upscanRequest)(
+        Transitions.submittedImportQuestionsContactInfo(preferUploadMultipleFiles)(upscanRequest)(
           upscanInitiateConnector.initiate(_)
         )
       )
@@ -356,6 +356,9 @@ class CreateCaseJourneyController @Inject() (
     * coming from one of our own pages open in the browser.
     */
   final val COOKIE_JSENABLED = "jsenabled"
+
+  final def preferUploadMultipleFiles(implicit rh: RequestHeader): Boolean =
+    rh.cookies.get(COOKIE_JSENABLED).isDefined && appConfig.uploadMultipleFilesFeature
 
   final def successRedirect(implicit rh: RequestHeader) =
     appConfig.baseExternalCallbackUrl + (rh.cookies.get(COOKIE_JSENABLED) match {

--- a/app/uk/gov/hmrc/traderservices/controllers/CreateCaseJourneyController.scala
+++ b/app/uk/gov/hmrc/traderservices/controllers/CreateCaseJourneyController.scala
@@ -395,13 +395,13 @@ class CreateCaseJourneyController @Inject() (
       expectedContentType = Some(appConfig.fileFormats.approvedFileTypes)
     )
 
-  // GET /new/upload-multiple-files
+  // GET /new/upload-files
   final val showUploadMultipleFiles: Action[AnyContent] =
     whenAuthorisedAsUser
       .apply(FileUploadTransitions.toUploadMultipleFiles)
       .redirectOrDisplayIf[FileUploadState.UploadMultipleFiles]
 
-  // PUT /new/upload-multiple-files/initialise/:uploadId
+  // PUT /new/upload-files/initialise/:uploadId
   final def initiateNextFileUpload(uploadId: String): Action[AnyContent] =
     whenAuthorisedAsUser
       .applyWithRequest { implicit request =>

--- a/app/uk/gov/hmrc/traderservices/controllers/CreateCaseJourneyController.scala
+++ b/app/uk/gov/hmrc/traderservices/controllers/CreateCaseJourneyController.scala
@@ -758,7 +758,8 @@ class CreateCaseJourneyController @Inject() (
             model.exportQuestionsAnswers,
             model.fileUploadsOpt.getOrElse(FileUploads()),
             controller.createCase,
-            controller.showFileUploaded
+            if (preferUploadMultipleFiles) controller.showUploadMultipleFiles
+            else controller.showFileUploaded
           )
         )
 
@@ -854,7 +855,8 @@ class CreateCaseJourneyController @Inject() (
             model.importQuestionsAnswers,
             model.fileUploadsOpt.getOrElse(FileUploads()),
             controller.createCase,
-            controller.showFileUploaded
+            if (preferUploadMultipleFiles) controller.showUploadMultipleFiles
+            else controller.showFileUploaded
           )
         )
 

--- a/app/uk/gov/hmrc/traderservices/controllers/CreateCaseJourneyController.scala
+++ b/app/uk/gov/hmrc/traderservices/controllers/CreateCaseJourneyController.scala
@@ -1001,6 +1001,7 @@ class CreateCaseJourneyController @Inject() (
   ): Result =
     state match {
       case s: FileUploadState => NoContent
+      case _                  => BadRequest
     }
 
   private def streamFileFromUspcan(

--- a/app/uk/gov/hmrc/traderservices/controllers/CreateCaseJourneyController.scala
+++ b/app/uk/gov/hmrc/traderservices/controllers/CreateCaseJourneyController.scala
@@ -1154,7 +1154,7 @@ object CreateCaseJourneyController {
   val UpscanUploadSuccessForm = Form[S3UploadSuccess](
     mapping(
       "key"    -> nonEmptyText,
-      "bucket" -> nonEmptyText
+      "bucket" -> optional(nonEmptyText)
     )(S3UploadSuccess.apply)(S3UploadSuccess.unapply)
   )
 

--- a/app/uk/gov/hmrc/traderservices/journeys/AmendCaseJourneyStateFormats.scala
+++ b/app/uk/gov/hmrc/traderservices/journeys/AmendCaseJourneyStateFormats.scala
@@ -43,21 +43,26 @@ object AmendCaseJourneyStateFormats
     case s: FileUploaded               => fileUploadedFormat.writes(s)
     case s: WaitingForFileVerification => waitingForFileVerificationFormat.writes(s)
     case s: AmendCaseSummary           => amendCaseSummaryFormat.writes(s)
+    case s: UploadMultipleFiles        => uploadMultipleFilesFormat.writes(s)
     case s: AmendCaseConfirmation      => amendCaseConfirmationFormat.writes(s)
   }
 
   override def deserializeState(stateName: String, properties: JsValue): JsResult[State] =
     stateName match {
-      case "Start"                      => JsSuccess(Start)
-      case "EnterCaseReferenceNumber"   => enterCaseReferenceNumberFormat.reads(properties)
-      case "SelectTypeOfAmendment"      => selectTypeOfAmendmentFormat.reads(properties)
-      case "EnterResponseText"          => enterResponseTextFormat.reads(properties)
-      case "UploadFile"                 => uploadFileFormat.reads(properties)
-      case "FileUploaded"               => fileUploadedFormat.reads(properties)
-      case "WaitingForFileVerification" => waitingForFileVerificationFormat.reads(properties)
-      case "AmendCaseSummary"           => amendCaseSummaryFormat.reads(properties)
-      case "AmendCaseConfirmation"      => amendCaseConfirmationFormat.reads(properties)
-      case "WorkInProgressDeadEnd"      => JsSuccess(WorkInProgressDeadEnd)
-      case _                            => JsError(s"Unknown state name $stateName")
+      case "Start"                    => JsSuccess(Start)
+      case "EnterCaseReferenceNumber" => enterCaseReferenceNumberFormat.reads(properties)
+      case "SelectTypeOfAmendment"    => selectTypeOfAmendmentFormat.reads(properties)
+      case "EnterResponseText"        => enterResponseTextFormat.reads(properties)
+      case "UploadFile"               => uploadFileFormat.reads(properties)
+      case "FileUploaded"             => fileUploadedFormat.reads(properties)
+      case "WaitingForFileVerification" =>
+        waitingForFileVerificationFormat.reads(properties)
+      case "AmendCaseSummary" =>
+        amendCaseSummaryFormat.reads(properties)
+      case "UploadMultipleFiles" =>
+        uploadMultipleFilesFormat.reads(properties)
+      case "AmendCaseConfirmation" => amendCaseConfirmationFormat.reads(properties)
+      case "WorkInProgressDeadEnd" => JsSuccess(WorkInProgressDeadEnd)
+      case _                       => JsError(s"Unknown state name $stateName")
     }
 }

--- a/app/uk/gov/hmrc/traderservices/journeys/CreateCaseJourneyModel.scala
+++ b/app/uk/gov/hmrc/traderservices/journeys/CreateCaseJourneyModel.scala
@@ -558,7 +558,7 @@ object CreateCaseJourneyModel extends FileUploadJourneyModelMixin {
           }
       }
 
-    final def submittedExportQuestionsContactInfo(
+    final def submittedExportQuestionsContactInfo(uploadMultipleFiles: Boolean)(
       upscanRequest: UpscanInitiateRequest
     )(upscanInitiate: UpscanInitiateApi)(user: String)(contactInfo: ExportContactInfo)(implicit ec: ExecutionContext) =
       Transition {
@@ -568,8 +568,12 @@ object CreateCaseJourneyModel extends FileUploadJourneyModelMixin {
               model.updated(model.exportQuestionsAnswers.copy(contactInfo = Some(contactInfo)))
             )
           )(
-            FileUploadTransitions
-              .initiateFileUpload(upscanRequest)(upscanInitiate)(user)
+            if (uploadMultipleFiles)
+              FileUploadTransitions
+                .toUploadMultipleFiles(user)
+            else
+              FileUploadTransitions
+                .initiateFileUpload(upscanRequest)(upscanInitiate)(user)
           )
       }
 
@@ -756,7 +760,7 @@ object CreateCaseJourneyModel extends FileUploadJourneyModelMixin {
           }
       }
 
-    final def submittedImportQuestionsContactInfo(
+    final def submittedImportQuestionsContactInfo(uploadMultipleFiles: Boolean)(
       upscanRequest: UpscanInitiateRequest
     )(upscanInitiate: UpscanInitiateApi)(user: String)(contactInfo: ImportContactInfo)(implicit ec: ExecutionContext) =
       Transition {
@@ -766,8 +770,12 @@ object CreateCaseJourneyModel extends FileUploadJourneyModelMixin {
               model.updated(model.importQuestionsAnswers.copy(contactInfo = Some(contactInfo)))
             )
           )(
-            FileUploadTransitions
-              .initiateFileUpload(upscanRequest)(upscanInitiate)(user)
+            if (uploadMultipleFiles)
+              FileUploadTransitions
+                .toUploadMultipleFiles(user)
+            else
+              FileUploadTransitions
+                .initiateFileUpload(upscanRequest)(upscanInitiate)(user)
           )
       }
 

--- a/app/uk/gov/hmrc/traderservices/journeys/CreateCaseJourneyStateFormats.scala
+++ b/app/uk/gov/hmrc/traderservices/journeys/CreateCaseJourneyStateFormats.scala
@@ -79,6 +79,7 @@ object CreateCaseJourneyStateFormats
     case s: UploadFile                               => uploadFileFormat.writes(s)
     case s: FileUploaded                             => fileUploadedFormat.writes(s)
     case s: WaitingForFileVerification               => waitingForFileVerificationFormat.writes(s)
+    case s: UploadMultipleFiles                      => uploadMultipleFilesFormat.writes(s)
     case s: CreateCaseConfirmation                   => createCaseConfirmationFormat.writes(s)
     case s: CaseAlreadyExists                        => caseAlreadyExistsFormat.writes(s)
   }
@@ -113,6 +114,7 @@ object CreateCaseJourneyStateFormats
       case "UploadFile"                       => uploadFileFormat.reads(properties)
       case "FileUploaded"                     => fileUploadedFormat.reads(properties)
       case "WaitingForFileVerification"       => waitingForFileVerificationFormat.reads(properties)
+      case "UploadMultipleFiles"              => uploadMultipleFilesFormat.reads(properties)
       case "CreateCaseConfirmation"           => createCaseConfirmationFormat.reads(properties)
       case "CaseAlreadyExists"                => caseAlreadyExistsFormat.reads(properties)
       case "WorkInProgressDeadEnd"            => JsSuccess(WorkInProgressDeadEnd)

--- a/app/uk/gov/hmrc/traderservices/journeys/FileUploadJourneyModelMixin.scala
+++ b/app/uk/gov/hmrc/traderservices/journeys/FileUploadJourneyModelMixin.scala
@@ -82,6 +82,12 @@ trait FileUploadJourneyModelMixin extends JourneyModel {
       acknowledged: Boolean = false
     ) extends FileUploadState
 
+    case class UploadMultipleFiles(
+      hostData: FileUploadHostData,
+      uploadRequestMap: Map[String, UploadRequest],
+      fileUploads: FileUploads
+    ) extends FileUploadState
+
   }
 
   type UpscanInitiateApi = UpscanInitiateRequest => Future[UpscanInitiateResponse]

--- a/app/uk/gov/hmrc/traderservices/journeys/FileUploadJourneyModelMixin.scala
+++ b/app/uk/gov/hmrc/traderservices/journeys/FileUploadJourneyModelMixin.scala
@@ -488,6 +488,12 @@ trait FileUploadJourneyModelMixin extends JourneyModel {
               .apply(updatedCurrentState)
           else
             goto(updatedCurrentState)
+
+        case current: UploadMultipleFiles =>
+          val updatedFileUploads = current.fileUploads
+            .copy(files = current.fileUploads.files.filterNot(_.reference == reference))
+          val updatedCurrentState = current.copy(fileUploads = updatedFileUploads)
+          goto(updatedCurrentState)
       }
 
     final def backToFileUploaded(user: String) =

--- a/app/uk/gov/hmrc/traderservices/journeys/FileUploadJourneyModelMixin.scala
+++ b/app/uk/gov/hmrc/traderservices/journeys/FileUploadJourneyModelMixin.scala
@@ -137,6 +137,10 @@ trait FileUploadJourneyModelMixin extends JourneyModel {
               fileUploads = state.fileUploadsOpt.getOrElse(FileUploads())
             )
           )
+
+        case state: FileUploadState =>
+          goto(UploadMultipleFiles(state.hostData, state.fileUploads))
+
       }
 
     final def initiateNextFileUpload(uploadId: String)(
@@ -207,6 +211,16 @@ trait FileUploadJourneyModelMixin extends JourneyModel {
               Some(fileUploads),
               showUploadSummaryIfAny = false
             )
+
+        case UploadMultipleFiles(hostData, fileUploads) =>
+          gotoFileUploadOrUploaded(
+            hostData,
+            upscanRequest,
+            upscanInitiate,
+            Some(fileUploads),
+            showUploadSummaryIfAny = false
+          )
+
       }
 
     final def markUploadAsRejected(user: String)(error: S3UploadError) =

--- a/app/uk/gov/hmrc/traderservices/journeys/FileUploadJourneyStateFormats.scala
+++ b/app/uk/gov/hmrc/traderservices/journeys/FileUploadJourneyStateFormats.scala
@@ -93,12 +93,10 @@ abstract class FileUploadJourneyStateFormats[M <: FileUploadJourneyModelMixin](v
   lazy val uploadMultipleFilesFormat = Format(
     (
       (__ \ "hostData").read[model.FileUploadHostData](fileUploadHostDataFormat) and
-        (__ \ "uploadRequestMap").read(uploadRequestMapFormat) and
         (__ \ "fileUploads").read[FileUploads]
     )(UploadMultipleFiles.apply _),
     (
       (__ \ "hostData").write[model.FileUploadHostData](fileUploadHostDataFormat) and
-        (__ \ "uploadRequestMap").write(uploadRequestMapFormat) and
         (__ \ "fileUploads").write[FileUploads]
     )(unlift(UploadMultipleFiles.unapply))
   )

--- a/app/uk/gov/hmrc/traderservices/journeys/FileUploadJourneyStateFormats.scala
+++ b/app/uk/gov/hmrc/traderservices/journeys/FileUploadJourneyStateFormats.scala
@@ -76,10 +76,38 @@ abstract class FileUploadJourneyStateFormats[M <: FileUploadJourneyModelMixin](v
     )(unlift(FileUploaded.unapply))
   )
 
+  private val uploadRequestMapFormat: Format[Map[String, UploadRequest]] = {
+    val uploadRequestFormat = implicitly[Format[UploadRequest]]
+    Format(
+      Reads[Map[String, UploadRequest]] {
+        case obj: JsObject => JsSuccess(obj.fields.map { case (k, v) => (k, uploadRequestFormat.reads(v).get) }.toMap)
+        case other         => JsError(s"Expected JsObject, but got ${other.getClass().getSimpleName()}.")
+      },
+      Writes[Map[String, UploadRequest]] {
+        case uploadRequestMap =>
+          JsObject(uploadRequestMap.mapValues(uploadRequestFormat.writes(_)))
+      }
+    )
+  }
+
+  lazy val uploadMultipleFilesFormat = Format(
+    (
+      (__ \ "hostData").read[model.FileUploadHostData](fileUploadHostDataFormat) and
+        (__ \ "uploadRequestMap").read(uploadRequestMapFormat) and
+        (__ \ "fileUploads").read[FileUploads]
+    )(UploadMultipleFiles.apply _),
+    (
+      (__ \ "hostData").write[model.FileUploadHostData](fileUploadHostDataFormat) and
+        (__ \ "uploadRequestMap").write(uploadRequestMapFormat) and
+        (__ \ "fileUploads").write[FileUploads]
+    )(unlift(UploadMultipleFiles.unapply))
+  )
+
   val serializeFileUploadStateProperties: PartialFunction[model.State, JsValue] = {
     case s: UploadFile                 => uploadFileFormat.writes(s)
     case s: FileUploaded               => fileUploadedFormat.writes(s)
     case s: WaitingForFileVerification => waitingForFileVerificationFormat.writes(s)
+    case s: UploadMultipleFiles        => uploadMultipleFilesFormat.writes(s)
   }
 
   def deserializeFileUploadState(stateName: String, properties: JsValue): JsResult[model.State] =
@@ -87,6 +115,7 @@ abstract class FileUploadJourneyStateFormats[M <: FileUploadJourneyModelMixin](v
       case "UploadFile"                 => uploadFileFormat.reads(properties)
       case "FileUploaded"               => fileUploadedFormat.reads(properties)
       case "WaitingForFileVerification" => waitingForFileVerificationFormat.reads(properties)
+      case "UploadMultipleFiles"        => uploadMultipleFilesFormat.reads(properties)
     }
 
 }

--- a/app/uk/gov/hmrc/traderservices/models/S3UploadSuccess.scala
+++ b/app/uk/gov/hmrc/traderservices/models/S3UploadSuccess.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.traderservices.models
+
+import play.api.libs.json.{Format, Json}
+
+/**
+  * Details of the S3 file upload success.
+  *
+  * The query parameter named key contains the globally unique file reference
+  * that was allocated by the initiate request to identify the upload.
+  *
+  * @param key file upload reference
+  * @param bucket upscan inbound bucket name
+  */
+case class S3UploadSuccess(
+  key: String,
+  bucket: String
+)
+
+object S3UploadSuccess {
+  implicit val formats: Format[S3UploadSuccess] =
+    Json.format[S3UploadSuccess]
+}

--- a/app/uk/gov/hmrc/traderservices/models/S3UploadSuccess.scala
+++ b/app/uk/gov/hmrc/traderservices/models/S3UploadSuccess.scala
@@ -25,11 +25,11 @@ import play.api.libs.json.{Format, Json}
   * that was allocated by the initiate request to identify the upload.
   *
   * @param key file upload reference
-  * @param bucket upscan inbound bucket name
+  * @param bucket upscan inbound bucket name, optional
   */
 case class S3UploadSuccess(
   key: String,
-  bucket: String
+  bucket: Option[String]
 )
 
 object S3UploadSuccess {

--- a/app/uk/gov/hmrc/traderservices/views/AmendCaseViews.scala
+++ b/app/uk/gov/hmrc/traderservices/views/AmendCaseViews.scala
@@ -29,5 +29,6 @@ class AmendCaseViews @Inject() (
   val fileUploadedView: FileUploadedView,
   val fileUploadedSummaryView: FileUploadedSummaryView,
   val amendCaseSummaryView: AmendCaseSummaryView,
+  val uploadMultipleFilesView: UploadMultipleFilesView,
   val amendCaseConfirmationView: AmendCaseConfirmationView
 )

--- a/app/uk/gov/hmrc/traderservices/views/CreateCaseViews.scala
+++ b/app/uk/gov/hmrc/traderservices/views/CreateCaseViews.scala
@@ -46,6 +46,7 @@ class CreateCaseViews @Inject() (
   val waitingForFileVerificationView: WaitingForFileVerificationView,
   val fileUploadedView: FileUploadedView,
   val fileUploadedSummaryView: FileUploadedSummaryView,
+  val uploadMultipleFilesView: UploadMultipleFilesView,
   val createCaseConfirmationView: CreateCaseConfirmationView,
   val caseAlreadyExistsView: CaseAlreadyExistsView
 )

--- a/app/uk/gov/hmrc/traderservices/views/UploadFileViewContext.scala
+++ b/app/uk/gov/hmrc/traderservices/views/UploadFileViewContext.scala
@@ -39,7 +39,7 @@ class UploadFileViewContext @Inject() (appConfig: AppConfig) {
         FormError("file", Seq(toMessageKey(details)))
 
       case DuplicateFileUpload(checksum, existingFileName, duplicateFileName) =>
-        FormError("file", Seq("error.file-upload.duplicate"))
+        FormError("file", Seq(duplicateFileMessageKey))
     }
 
   def toMessageKey(error: S3UploadError): String =
@@ -57,4 +57,6 @@ class UploadFileViewContext @Inject() (appConfig: AppConfig) {
       case UpscanNotification.REJECTED   => "error.file-upload.invalid-type"
       case UpscanNotification.UNKNOWN    => "error.file-upload.unknown"
     }
+
+  val duplicateFileMessageKey: String = "error.file-upload.duplicate"
 }

--- a/app/uk/gov/hmrc/traderservices/views/UploadMultipleFilesView.scala.html
+++ b/app/uk/gov/hmrc/traderservices/views/UploadMultipleFilesView.scala.html
@@ -29,7 +29,7 @@
         context: UploadFileViewContext
 )
 
-@(maxFileUploadsNumber: Int, initialFileUploads: Seq[FileUpload], initiateNextFileUpload: String => Call, checkFileVerificationStatus: String => Call, continueAction: Call, backLink: Call)(implicit request: Request[_], messages: Messages)
+@(maxFileUploadsNumber: Int, initialFileUploads: Seq[FileUpload], initiateNextFileUpload: String => Call, checkFileVerificationStatus: String => Call, removeFile: String => Call, continueAction: Call, backLink: Call)(implicit request: Request[_], messages: Messages)
 
 @govukLayout(
   pageTitle("view.upload-multiple-files.title"),
@@ -37,14 +37,30 @@
 ) {
 
   @*
-   * checkFileVerificationStatus - function accepting upscan reference and returning a call,
-   *     which will return 200 with JSON payload, i.e. one of: 
+   * Available parameters:
+   * + maxFileUploadsNumber - this is the value the frontend service will check file upload list against, 
+   *                          if number of upload will exceed the limit, user will be not able to progress
+   *
+   * + initialFileUploads - existing file uploads in different states, 
+   *                        use to provide initial input for multi-file upload script
+   *
+   * + initiateNextFileUpload - a function accepting UPLOAD_ID (some unique string) and returning a call to frontend service,
+   *                            PUT request to this call will provision new file upload and return 200 with JSON result 
+              {"uploadId":"123abc","upscanReference":"f029444f-415c-4dec-9cf2-36774ec63ab8","uploadRequest":{"href":"https://s3.amazonaws.com/bucket/123abc","fields":{"foo1":"bar1"}}}      
+   * 
+   * + checkFileVerificationStatus - a function accepting upscan reference and returning a call to frontend service,
+   *                                 GET request to this call will return either 404 or 200 with JSON status, i.e. one of: 
    *         - {"fileStatus":"NOT_UPLOADED","uploadRequest":{"href":"https://s3.amazonaws.com/bucket/123abc","fields":{"foo1":"bar1"}}}
    *         - {"fileStatus":"POSTED"}
    *         - {"fileStatus":"ACCEPTED","fileMimeType":"application/pdf","fileName":"test.pdf","previewUrl":"/send-documents-for-customs-check/new/file-uploaded/f029444f-415c-4dec-9cf2-36774ec63ab8"}
    *         - {"fileStatus":"FAILED","errorMessage":"The selected file contains a virus - upload a different one"}
    *         - {"fileStatus":"REJECTED","errorMessage":"The selected file could not be uploaded"}
    *         - {"fileStatus":"DUPLICATE","errorMessage":"The selected file has already been uploaded"}
+   *
+   * + removeFile - a function accepting upscan reference and returning a call to frontend service,
+   *                PUT request to this call will remove specified file upload and return 204
+   * 
+   * + continueAction - a call to proceed next (i.e. to the check-your-answers page)
    *@
 
   @html.h1(messages("view.upload-multiple-files.heading"), classes = "govuk-heading-l")

--- a/app/uk/gov/hmrc/traderservices/views/UploadMultipleFilesView.scala.html
+++ b/app/uk/gov/hmrc/traderservices/views/UploadMultipleFilesView.scala.html
@@ -49,4 +49,8 @@
 
   @html.h1(messages("view.upload-multiple-files.heading"), classes = "govuk-heading-l")
 
+  @forms.formWithCSRF(action = continueAction, args = 'novalidate -> "novalidate") {
+      @html.button("form.upload-multiple-files.continue")
+  }
+
 }

--- a/app/uk/gov/hmrc/traderservices/views/UploadMultipleFilesView.scala.html
+++ b/app/uk/gov/hmrc/traderservices/views/UploadMultipleFilesView.scala.html
@@ -1,0 +1,52 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.traderservices.models.{FileUploads,FileUpload,UploadRequest,FileUploadError}
+@import uk.gov.hmrc.traderservices.wiring.AppConfig
+@import uk.gov.hmrc.traderservices.views.UploadFileViewContext
+
+@this(
+        govukLayout: uk.gov.hmrc.traderservices.views.html.templates.GovukLayoutWrapper,
+        forms: uk.gov.hmrc.traderservices.views.components.forms,
+        html: uk.gov.hmrc.traderservices.views.components.html,
+        details: uk.gov.hmrc.traderservices.views.html.components.details,
+        govukFileUpload: GovukFileUpload,
+        govukButton: GovukButton,
+        appConfig: AppConfig,
+        context: UploadFileViewContext
+)
+
+@(maxFileUploadsNumber: Int, initialFileUploads: Seq[FileUpload], initiateNextFileUpload: String => Call, checkFileVerificationStatus: String => Call, continueAction: Call, backLink: Call)(implicit request: Request[_], messages: Messages)
+
+@govukLayout(
+  pageTitle("view.upload-multiple-files.title"),
+  backLink = Some(backLink.url)
+) {
+
+  @*
+   * checkFileVerificationStatus - function accepting upscan reference and returning a call,
+   *     which will return 200 with JSON payload, i.e. one of: 
+   *         - {"fileStatus":"NOT_UPLOADED","uploadRequest":{"href":"https://s3.amazonaws.com/bucket/123abc","fields":{"foo1":"bar1"}}}
+   *         - {"fileStatus":"POSTED"}
+   *         - {"fileStatus":"ACCEPTED","fileMimeType":"application/pdf","fileName":"test.pdf","previewUrl":"/send-documents-for-customs-check/new/file-uploaded/f029444f-415c-4dec-9cf2-36774ec63ab8"}
+   *         - {"fileStatus":"FAILED","errorMessage":"The selected file contains a virus - upload a different one"}
+   *         - {"fileStatus":"REJECTED","errorMessage":"The selected file could not be uploaded"}
+   *         - {"fileStatus":"DUPLICATE","errorMessage":"The selected file has already been uploaded"}
+   *@
+
+  @html.h1(messages("view.upload-multiple-files.heading"), classes = "govuk-heading-l")
+
+}

--- a/app/uk/gov/hmrc/traderservices/wiring/AppConfig.scala
+++ b/app/uk/gov/hmrc/traderservices/wiring/AppConfig.scala
@@ -77,6 +77,8 @@ trait AppConfig {
 
   val timeout: Int
   val countdown: Int
+
+  val uploadMultipleFilesFeature: Boolean
 }
 
 class AppConfigImpl @Inject() (config: ServicesConfig) extends AppConfig {
@@ -137,4 +139,5 @@ class AppConfigImpl @Inject() (config: ServicesConfig) extends AppConfig {
 
   override val traceFSM: Boolean = config.getBoolean("trace.fsm")
 
+  override val uploadMultipleFilesFeature: Boolean = config.getBoolean("features.uploadMultipleFiles")
 }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -79,8 +79,13 @@ POST       /add/type-of-amendment                                   @uk.gov.hmrc
 GET        /add/write-response                                      @uk.gov.hmrc.traderservices.controllers.AmendCaseJourneyController.showEnterResponseText
 POST       /add/write-response                                      @uk.gov.hmrc.traderservices.controllers.AmendCaseJourneyController.submitResponseText
 
+GET        /add/upload-multiple-files                               @uk.gov.hmrc.traderservices.controllers.AmendCaseJourneyController.showUploadMultipleFiles
++ nocsrf
+PUT        /add/upload-multiple-files/initiate-next                 @uk.gov.hmrc.traderservices.controllers.AmendCaseJourneyController.initiateNextFileUpload(uploadId: String)
+
 GET        /add/file-upload                                         @uk.gov.hmrc.traderservices.controllers.AmendCaseJourneyController.showFileUpload
 GET        /add/file-rejected                                       @uk.gov.hmrc.traderservices.controllers.AmendCaseJourneyController.markFileUploadAsRejected
+GET        /add/journey/:journeyId/file-posted                      @uk.gov.hmrc.traderservices.controllers.AmendCaseJourneyController.asyncMarkFileUploadAsPosted(journeyId: String)
 GET        /add/journey/:journeyId/file-rejected                    @uk.gov.hmrc.traderservices.controllers.AmendCaseJourneyController.asyncMarkFileUploadAsRejected(journeyId: String)
 GET        /add/file-verification                                   @uk.gov.hmrc.traderservices.controllers.AmendCaseJourneyController.showWaitingForFileVerification
 GET        /add/journey/:journeyId/file-verification                @uk.gov.hmrc.traderservices.controllers.AmendCaseJourneyController.asyncWaitingForFileVerification(journeyId: String)
@@ -88,6 +93,7 @@ GET        /add/file-verification/:reference/status                 @uk.gov.hmrc
 GET        /add/file-uploaded                                       @uk.gov.hmrc.traderservices.controllers.AmendCaseJourneyController.showFileUploaded
 POST       /add/file-uploaded                                       @uk.gov.hmrc.traderservices.controllers.AmendCaseJourneyController.submitUploadAnotherFileChoice
 GET        /add/file-uploaded/:reference/remove                     @uk.gov.hmrc.traderservices.controllers.AmendCaseJourneyController.removeFileUploadByReference(reference: String)
+PUT        /add/file-uploaded/:reference/remove                     @uk.gov.hmrc.traderservices.controllers.AmendCaseJourneyController.removeFileUploadByReferenceAsync(reference: String)
 GET        /add/file-uploaded/:reference                            @uk.gov.hmrc.traderservices.controllers.AmendCaseJourneyController.previewFileUploadByReference(reference: String)
 + nocsrf
 POST       /add/journey/:journeyId/callback-from-upscan             @uk.gov.hmrc.traderservices.controllers.AmendCaseJourneyController.callbackFromUpscan(journeyId: String)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -62,6 +62,7 @@ GET        /new/file-verification/:reference/status                 @uk.gov.hmrc
 GET        /new/file-uploaded                                       @uk.gov.hmrc.traderservices.controllers.CreateCaseJourneyController.showFileUploaded
 POST       /new/file-uploaded                                       @uk.gov.hmrc.traderservices.controllers.CreateCaseJourneyController.submitUploadAnotherFileChoice
 GET        /new/file-uploaded/:reference/remove                     @uk.gov.hmrc.traderservices.controllers.CreateCaseJourneyController.removeFileUploadByReference(reference: String)
+PUT        /new/file-uploaded/:reference/remove                     @uk.gov.hmrc.traderservices.controllers.CreateCaseJourneyController.removeFileUploadByReferenceAsync(reference: String)
 GET        /new/file-uploaded/:reference                            @uk.gov.hmrc.traderservices.controllers.CreateCaseJourneyController.previewFileUploadByReference(reference: String)
 + nocsrf
 POST       /new/journey/:journeyId/callback-from-upscan             @uk.gov.hmrc.traderservices.controllers.CreateCaseJourneyController.callbackFromUpscan(journeyId: String)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -48,8 +48,13 @@ GET        /new/import/contact-information                          @uk.gov.hmrc
 POST       /new/import/contact-information                          @uk.gov.hmrc.traderservices.controllers.CreateCaseJourneyController.submitImportQuestionsContactInfoAnswer
 GET        /new/import/check-your-answers                           @uk.gov.hmrc.traderservices.controllers.CreateCaseJourneyController.showImportQuestionsSummary
 
+GET        /new/upload-multiple-files                               @uk.gov.hmrc.traderservices.controllers.CreateCaseJourneyController.showUploadMultipleFiles
++ nocsrf
+PUT        /new/upload-multiple-files/initiate-next                 @uk.gov.hmrc.traderservices.controllers.CreateCaseJourneyController.initiateNextFileUpload(uploadId: String)
+
 GET        /new/file-upload                                         @uk.gov.hmrc.traderservices.controllers.CreateCaseJourneyController.showFileUpload
 GET        /new/file-rejected                                       @uk.gov.hmrc.traderservices.controllers.CreateCaseJourneyController.markFileUploadAsRejected
+GET        /new/journey/:journeyId/file-posted                      @uk.gov.hmrc.traderservices.controllers.CreateCaseJourneyController.asyncMarkFileUploadAsPosted(journeyId: String)
 GET        /new/journey/:journeyId/file-rejected                    @uk.gov.hmrc.traderservices.controllers.CreateCaseJourneyController.asyncMarkFileUploadAsRejected(journeyId: String)
 GET        /new/file-verification                                   @uk.gov.hmrc.traderservices.controllers.CreateCaseJourneyController.showWaitingForFileVerification
 GET        /new/journey/:journeyId/file-verification                @uk.gov.hmrc.traderservices.controllers.CreateCaseJourneyController.asyncWaitingForFileVerification(journeyId: String)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -48,9 +48,9 @@ GET        /new/import/contact-information                          @uk.gov.hmrc
 POST       /new/import/contact-information                          @uk.gov.hmrc.traderservices.controllers.CreateCaseJourneyController.submitImportQuestionsContactInfoAnswer
 GET        /new/import/check-your-answers                           @uk.gov.hmrc.traderservices.controllers.CreateCaseJourneyController.showImportQuestionsSummary
 
-GET        /new/upload-multiple-files                               @uk.gov.hmrc.traderservices.controllers.CreateCaseJourneyController.showUploadMultipleFiles
+GET        /new/upload-files                                        @uk.gov.hmrc.traderservices.controllers.CreateCaseJourneyController.showUploadMultipleFiles
 + nocsrf
-PUT        /new/upload-multiple-files/initialise/:uploadId          @uk.gov.hmrc.traderservices.controllers.CreateCaseJourneyController.initiateNextFileUpload(uploadId: String)
+PUT        /new/upload-files/initialise/:uploadId                   @uk.gov.hmrc.traderservices.controllers.CreateCaseJourneyController.initiateNextFileUpload(uploadId: String)
 
 GET        /new/file-upload                                         @uk.gov.hmrc.traderservices.controllers.CreateCaseJourneyController.showFileUpload
 GET        /new/file-rejected                                       @uk.gov.hmrc.traderservices.controllers.CreateCaseJourneyController.markFileUploadAsRejected
@@ -62,6 +62,7 @@ GET        /new/file-verification/:reference/status                 @uk.gov.hmrc
 GET        /new/file-uploaded                                       @uk.gov.hmrc.traderservices.controllers.CreateCaseJourneyController.showFileUploaded
 POST       /new/file-uploaded                                       @uk.gov.hmrc.traderservices.controllers.CreateCaseJourneyController.submitUploadAnotherFileChoice
 GET        /new/file-uploaded/:reference/remove                     @uk.gov.hmrc.traderservices.controllers.CreateCaseJourneyController.removeFileUploadByReference(reference: String)
++ nocsrf
 PUT        /new/file-uploaded/:reference/remove                     @uk.gov.hmrc.traderservices.controllers.CreateCaseJourneyController.removeFileUploadByReferenceAsync(reference: String)
 GET        /new/file-uploaded/:reference                            @uk.gov.hmrc.traderservices.controllers.CreateCaseJourneyController.previewFileUploadByReference(reference: String)
 + nocsrf
@@ -79,9 +80,9 @@ POST       /add/type-of-amendment                                   @uk.gov.hmrc
 GET        /add/write-response                                      @uk.gov.hmrc.traderservices.controllers.AmendCaseJourneyController.showEnterResponseText
 POST       /add/write-response                                      @uk.gov.hmrc.traderservices.controllers.AmendCaseJourneyController.submitResponseText
 
-GET        /add/upload-multiple-files                               @uk.gov.hmrc.traderservices.controllers.AmendCaseJourneyController.showUploadMultipleFiles
+GET        /add/upload-files                                        @uk.gov.hmrc.traderservices.controllers.AmendCaseJourneyController.showUploadMultipleFiles
 + nocsrf
-PUT        /add/upload-multiple-files/initialise/:uploadId          @uk.gov.hmrc.traderservices.controllers.AmendCaseJourneyController.initiateNextFileUpload(uploadId: String)
+PUT        /add/upload-files/initialise/:uploadId                   @uk.gov.hmrc.traderservices.controllers.AmendCaseJourneyController.initiateNextFileUpload(uploadId: String)
 
 GET        /add/file-upload                                         @uk.gov.hmrc.traderservices.controllers.AmendCaseJourneyController.showFileUpload
 GET        /add/file-rejected                                       @uk.gov.hmrc.traderservices.controllers.AmendCaseJourneyController.markFileUploadAsRejected
@@ -93,6 +94,7 @@ GET        /add/file-verification/:reference/status                 @uk.gov.hmrc
 GET        /add/file-uploaded                                       @uk.gov.hmrc.traderservices.controllers.AmendCaseJourneyController.showFileUploaded
 POST       /add/file-uploaded                                       @uk.gov.hmrc.traderservices.controllers.AmendCaseJourneyController.submitUploadAnotherFileChoice
 GET        /add/file-uploaded/:reference/remove                     @uk.gov.hmrc.traderservices.controllers.AmendCaseJourneyController.removeFileUploadByReference(reference: String)
++ nocsrf
 PUT        /add/file-uploaded/:reference/remove                     @uk.gov.hmrc.traderservices.controllers.AmendCaseJourneyController.removeFileUploadByReferenceAsync(reference: String)
 GET        /add/file-uploaded/:reference                            @uk.gov.hmrc.traderservices.controllers.AmendCaseJourneyController.previewFileUploadByReference(reference: String)
 + nocsrf

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -50,7 +50,7 @@ GET        /new/import/check-your-answers                           @uk.gov.hmrc
 
 GET        /new/upload-multiple-files                               @uk.gov.hmrc.traderservices.controllers.CreateCaseJourneyController.showUploadMultipleFiles
 + nocsrf
-PUT        /new/upload-multiple-files/initiate-next                 @uk.gov.hmrc.traderservices.controllers.CreateCaseJourneyController.initiateNextFileUpload(uploadId: String)
+PUT        /new/upload-multiple-files/initialise/:uploadId          @uk.gov.hmrc.traderservices.controllers.CreateCaseJourneyController.initiateNextFileUpload(uploadId: String)
 
 GET        /new/file-upload                                         @uk.gov.hmrc.traderservices.controllers.CreateCaseJourneyController.showFileUpload
 GET        /new/file-rejected                                       @uk.gov.hmrc.traderservices.controllers.CreateCaseJourneyController.markFileUploadAsRejected
@@ -81,7 +81,7 @@ POST       /add/write-response                                      @uk.gov.hmrc
 
 GET        /add/upload-multiple-files                               @uk.gov.hmrc.traderservices.controllers.AmendCaseJourneyController.showUploadMultipleFiles
 + nocsrf
-PUT        /add/upload-multiple-files/initiate-next                 @uk.gov.hmrc.traderservices.controllers.AmendCaseJourneyController.initiateNextFileUpload(uploadId: String)
+PUT        /add/upload-multiple-files/initialise/:uploadId          @uk.gov.hmrc.traderservices.controllers.AmendCaseJourneyController.initiateNextFileUpload(uploadId: String)
 
 GET        /add/file-upload                                         @uk.gov.hmrc.traderservices.controllers.AmendCaseJourneyController.showFileUpload
 GET        /add/file-rejected                                       @uk.gov.hmrc.traderservices.controllers.AmendCaseJourneyController.markFileUploadAsRejected

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -196,3 +196,7 @@ session{
   timeoutSeconds = 900
   countdownInSeconds = 120
 }
+
+features {
+  uploadMultipleFiles = false
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -198,5 +198,5 @@ session{
 }
 
 features {
-  uploadMultipleFiles = true
+  uploadMultipleFiles = false
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -198,5 +198,5 @@ session{
 }
 
 features {
-  uploadMultipleFiles = false
+  uploadMultipleFiles = true
 }

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -431,6 +431,9 @@ summary.file-names=File names
 
 # File upload messages
 # ----------------------------------------------------------
+view.upload-multiple-files.heading=Upload your documents
+view.upload-multiple-files.title=Upload your documents
+
 view.upload-file.first.title=Upload your first document
 view.upload-file.first.heading=Upload your first document
 view.upload-file.first.fileLabel=Select the first file to upload
@@ -464,6 +467,7 @@ form.file-uploaded.uploadAnotherFile.yes=Yes
 form.file-uploaded.uploadAnotherFile.no=No
 form.file-uploaded.uploadAnotherFile.noConditional=By continuing, you will now submit all the documents you’ve uploaded
 form.file-uploaded.continue=Continue
+form.upload-multiple-files.continue=Continue
 
 error.file-upload.required=Select a file
 error.file-upload.invalid-size-small=The selected file is empty

--- a/it/uk/gov/hmrc/traderservices/controllers/AmendCaseJourneyISpec.scala
+++ b/it/uk/gov/hmrc/traderservices/controllers/AmendCaseJourneyISpec.scala
@@ -312,7 +312,12 @@ class AmendCaseJourneyISpec extends AmendCaseJourneyISpecSetup with TraderServic
           ),
           FileUploads(files =
             Seq(
-              FileUpload.Initiated(1, "11370e18-6e24-453e-b45a-76d3e32ea33d"),
+              FileUpload.Initiated(
+                1,
+                "11370e18-6e24-453e-b45a-76d3e32ea33d",
+                uploadRequest =
+                  Some(UploadRequest(href = "https://s3.amazonaws.com/bucket/123abc", fields = Map("foo1" -> "bar1")))
+              ),
               FileUpload.Posted(2, "2b72fe99-8adf-4edb-865e-622ae710f77c"),
               FileUpload.Accepted(
                 4,
@@ -327,6 +332,18 @@ class AmendCaseJourneyISpec extends AmendCaseJourneyISpecSetup with TraderServic
                 3,
                 "4b1e15a4-4152-4328-9448-4924d9aee6e2",
                 UpscanNotification.FailureDetails(UpscanNotification.QUARANTINE, "some reason")
+              ),
+              FileUpload.Rejected(
+                5,
+                "4b1e15a4-4152-4328-9448-4924d9aee6e3",
+                details = S3UploadError("key", "errorCode", "Invalid file type.")
+              ),
+              FileUpload.Duplicate(
+                6,
+                "4b1e15a4-4152-4328-9448-4924d9aee6e4",
+                checksum = "0" * 64,
+                existingFileName = "test1.pdf",
+                duplicateFileName = "test1.png"
               )
             )
           ),
@@ -341,7 +358,7 @@ class AmendCaseJourneyISpec extends AmendCaseJourneyISpecSetup with TraderServic
               .get()
           )
         result1.status shouldBe 200
-        result1.body shouldBe """{"fileStatus":"NOT_UPLOADED"}"""
+        result1.body shouldBe """{"fileStatus":"NOT_UPLOADED","uploadRequest":{"href":"https://s3.amazonaws.com/bucket/123abc","fields":{"foo1":"bar1"}}}"""
         journey.getState shouldBe state
 
         val result2 =
@@ -353,18 +370,30 @@ class AmendCaseJourneyISpec extends AmendCaseJourneyISpecSetup with TraderServic
         val result3 =
           await(request("/add/file-verification/f029444f-415c-4dec-9cf2-36774ec63ab8/status").get())
         result3.status shouldBe 200
-        result3.body shouldBe """{"fileStatus":"ACCEPTED"}"""
+        result3.body shouldBe """{"fileStatus":"ACCEPTED","fileMimeType":"application/pdf","fileName":"test.pdf","previewUrl":"/send-documents-for-customs-check/add/file-uploaded/f029444f-415c-4dec-9cf2-36774ec63ab8"}"""
         journey.getState shouldBe state
 
         val result4 =
           await(request("/add/file-verification/4b1e15a4-4152-4328-9448-4924d9aee6e2/status").get())
         result4.status shouldBe 200
-        result4.body shouldBe """{"fileStatus":"FAILED"}"""
+        result4.body shouldBe """{"fileStatus":"FAILED","errorMessage":"The selected file contains a virus - upload a different one"}"""
         journey.getState shouldBe state
 
         val result5 =
           await(request("/add/file-verification/f0e317f5-d394-42cc-93f8-e89f4fc0114c/status").get())
         result5.status shouldBe 404
+        journey.getState shouldBe state
+
+        val result6 =
+          await(request("/add/file-verification/4b1e15a4-4152-4328-9448-4924d9aee6e3/status").get())
+        result6.status shouldBe 200
+        result6.body shouldBe """{"fileStatus":"REJECTED","errorMessage":"The selected file could not be uploaded"}"""
+        journey.getState shouldBe state
+
+        val result7 =
+          await(request("/add/file-verification/4b1e15a4-4152-4328-9448-4924d9aee6e4/status").get())
+        result7.status shouldBe 200
+        result7.body shouldBe """{"fileStatus":"DUPLICATE","errorMessage":"The selected file has already been uploaded"}"""
         journey.getState shouldBe state
       }
     }

--- a/it/uk/gov/hmrc/traderservices/controllers/AmendCaseJourneyISpec.scala
+++ b/it/uk/gov/hmrc/traderservices/controllers/AmendCaseJourneyISpec.scala
@@ -153,7 +153,7 @@ class AmendCaseJourneyISpec extends AmendCaseJourneyISpecSetup with TraderServic
       }
     }
 
-    "GET /add/upload-multiple-files" should {
+    "GET /add/upload-files" should {
       "show the upload multiple files page when in UploadDocuments mode" in {
         implicit val journeyId: JourneyId = JourneyId()
         val state = UploadMultipleFiles(
@@ -166,7 +166,7 @@ class AmendCaseJourneyISpec extends AmendCaseJourneyISpecSetup with TraderServic
         journey.setState(state)
         givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
 
-        val result = await(request("/add/upload-multiple-files").get())
+        val result = await(request("/add/upload-files").get())
 
         result.status shouldBe 200
         result.body should include(htmlEscapedPageTitle("view.upload-multiple-files.title"))
@@ -187,7 +187,7 @@ class AmendCaseJourneyISpec extends AmendCaseJourneyISpecSetup with TraderServic
         journey.setState(state)
         givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
 
-        val result = await(request("/add/upload-multiple-files").get())
+        val result = await(request("/add/upload-files").get())
 
         result.status shouldBe 200
         result.body should include(htmlEscapedPageTitle("view.upload-multiple-files.title"))
@@ -206,7 +206,7 @@ class AmendCaseJourneyISpec extends AmendCaseJourneyISpecSetup with TraderServic
         journey.setState(state)
         givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
 
-        val result = await(request("/add/upload-multiple-files").get())
+        val result = await(request("/add/upload-files").get())
 
         result.status shouldBe 200
         result.body should include(htmlEscapedPageTitle("view.upload-multiple-files.title"))
@@ -232,7 +232,7 @@ class AmendCaseJourneyISpec extends AmendCaseJourneyISpecSetup with TraderServic
         journey.setState(state)
         givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
 
-        val result = await(request("/add/upload-multiple-files").get())
+        val result = await(request("/add/upload-files").get())
 
         result.status shouldBe 200
         result.body should include(htmlEscapedPageTitle("view.upload-multiple-files.title"))
@@ -248,7 +248,7 @@ class AmendCaseJourneyISpec extends AmendCaseJourneyISpecSetup with TraderServic
       }
     }
 
-    "PUT /add/upload-multiple-files/initialise/:uploadId" should {
+    "PUT /add/upload-files/initialise/:uploadId" should {
       "initialise first file upload" in {
         implicit val journeyId: JourneyId = JourneyId()
         val state = UploadMultipleFiles(
@@ -265,7 +265,7 @@ class AmendCaseJourneyISpec extends AmendCaseJourneyISpecSetup with TraderServic
           appConfig.baseInternalCallbackUrl + s"/send-documents-for-customs-check/add/journey/${journeyId.value}/callback-from-upscan"
         givenUpscanInitiateSucceeds(callbackUrl)
 
-        val result = await(request("/add/upload-multiple-files/initialise/001").put(""))
+        val result = await(request("/add/upload-files/initialise/001").put(""))
 
         result.status shouldBe 200
         val json = result.body[JsValue]
@@ -343,7 +343,7 @@ class AmendCaseJourneyISpec extends AmendCaseJourneyISpecSetup with TraderServic
           appConfig.baseInternalCallbackUrl + s"/send-documents-for-customs-check/add/journey/${journeyId.value}/callback-from-upscan"
         givenUpscanInitiateSucceeds(callbackUrl)
 
-        val result = await(request("/add/upload-multiple-files/initialise/002").put(""))
+        val result = await(request("/add/upload-files/initialise/002").put(""))
 
         result.status shouldBe 200
         val json = result.body[JsValue]

--- a/it/uk/gov/hmrc/traderservices/controllers/AmendCaseJourneyISpec.scala
+++ b/it/uk/gov/hmrc/traderservices/controllers/AmendCaseJourneyISpec.scala
@@ -653,6 +653,202 @@ class AmendCaseJourneyISpec extends AmendCaseJourneyISpecSetup with TraderServic
       }
     }
 
+    "GET /add/file-uploaded" should {
+      "show uploaded singular file view" in {
+        implicit val journeyId: JourneyId = JourneyId()
+        val state = FileUploaded(
+          AmendCaseModel(
+            caseReferenceNumber = Some("PC12010081330XGBNZJO04"),
+            typeOfAmendment = Some(TypeOfAmendment.UploadDocuments)
+          ),
+          fileUploads = FileUploads(files =
+            Seq(
+              FileUpload.Accepted(
+                1,
+                "11370e18-6e24-453e-b45a-76d3e32ea33d",
+                "https://s3.amazonaws.com/bucket/123",
+                ZonedDateTime.parse("2018-04-24T09:30:00Z"),
+                "396f101dd52e8b2ace0dcf5ed09b1d1f030e608938510ce46e7a5c7a4e775100",
+                "test.pdf",
+                "application/pdf"
+              )
+            )
+          )
+        )
+        journey.setState(state)
+        givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
+
+        val result = await(request("/add/file-uploaded").get())
+
+        result.status shouldBe 200
+        result.body should include(htmlEscapedPageTitle("view.file-uploaded.singular.title", "1"))
+        result.body should include(htmlEscapedMessage("view.file-uploaded.singular.heading", "1"))
+        journey.getState shouldBe state
+      }
+
+      "show uploaded plural file view" in {
+        implicit val journeyId: JourneyId = JourneyId()
+        val state = FileUploaded(
+          AmendCaseModel(
+            caseReferenceNumber = Some("PC12010081330XGBNZJO04"),
+            typeOfAmendment = Some(TypeOfAmendment.UploadDocuments)
+          ),
+          fileUploads = FileUploads(files =
+            Seq(
+              FileUpload.Accepted(
+                1,
+                "11370e18-6e24-453e-b45a-76d3e32ea33d",
+                "https://s3.amazonaws.com/bucket/123",
+                ZonedDateTime.parse("2018-04-24T09:30:00Z"),
+                "396f101dd52e8b2ace0dcf5ed09b1d1f030e608938510ce46e7a5c7a4e775100",
+                "test2.pdf",
+                "application/pdf"
+              ),
+              FileUpload.Accepted(
+                2,
+                "22370e18-6e24-453e-b45a-76d3e32ea33d",
+                "https://s3.amazonaws.com/bucket/123",
+                ZonedDateTime.parse("2018-04-24T09:30:00Z"),
+                "396f101dd52e8b2ace0dcf5ed09b1d1f030e608938510ce46e7a5c7a4e775100",
+                "test1.png",
+                "image/png"
+              )
+            )
+          )
+        )
+        journey.setState(state)
+        givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
+
+        val result = await(request("/add/file-uploaded").get())
+
+        result.status shouldBe 200
+        result.body should include(htmlEscapedPageTitle("view.file-uploaded.plural.title", "2"))
+        result.body should include(htmlEscapedMessage("view.file-uploaded.plural.heading", "2"))
+        journey.getState shouldBe state
+      }
+    }
+
+    "GET /add/file-uploaded/:reference/remove" should {
+      "remove file from upload list by reference" in {
+        implicit val journeyId: JourneyId = JourneyId()
+        val state = FileUploaded(
+          AmendCaseModel(
+            caseReferenceNumber = Some("PC12010081330XGBNZJO04"),
+            typeOfAmendment = Some(TypeOfAmendment.UploadDocuments)
+          ),
+          fileUploads = FileUploads(files =
+            Seq(
+              FileUpload.Accepted(
+                1,
+                "11370e18-6e24-453e-b45a-76d3e32ea33d",
+                "https://s3.amazonaws.com/bucket/123",
+                ZonedDateTime.parse("2018-04-24T09:30:00Z"),
+                "396f101dd52e8b2ace0dcf5ed09b1d1f030e608938510ce46e7a5c7a4e775100",
+                "test2.pdf",
+                "application/pdf"
+              ),
+              FileUpload.Accepted(
+                2,
+                "22370e18-6e24-453e-b45a-76d3e32ea33d",
+                "https://s3.amazonaws.com/bucket/123",
+                ZonedDateTime.parse("2018-04-24T09:30:00Z"),
+                "396f101dd52e8b2ace0dcf5ed09b1d1f030e608938510ce46e7a5c7a4e775100",
+                "test1.png",
+                "image/png"
+              )
+            )
+          )
+        )
+        journey.setState(state)
+        givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
+
+        val result = await(request("/add/file-uploaded/11370e18-6e24-453e-b45a-76d3e32ea33d/remove").get())
+
+        result.status shouldBe 200
+        result.body should include(htmlEscapedPageTitle("view.file-uploaded.singular.title", "1"))
+        result.body should include(htmlEscapedMessage("view.file-uploaded.singular.heading", "1"))
+        journey.getState shouldBe FileUploaded(
+          AmendCaseModel(
+            caseReferenceNumber = Some("PC12010081330XGBNZJO04"),
+            typeOfAmendment = Some(TypeOfAmendment.UploadDocuments)
+          ),
+          fileUploads = FileUploads(files =
+            Seq(
+              FileUpload.Accepted(
+                2,
+                "22370e18-6e24-453e-b45a-76d3e32ea33d",
+                "https://s3.amazonaws.com/bucket/123",
+                ZonedDateTime.parse("2018-04-24T09:30:00Z"),
+                "396f101dd52e8b2ace0dcf5ed09b1d1f030e608938510ce46e7a5c7a4e775100",
+                "test1.png",
+                "image/png"
+              )
+            )
+          )
+        )
+      }
+    }
+
+    "PUT /add/file-uploaded/:reference/remove" should {
+      "remove file from upload list by reference" in {
+        implicit val journeyId: JourneyId = JourneyId()
+        val state = UploadMultipleFiles(
+          AmendCaseModel(
+            caseReferenceNumber = Some("PC12010081330XGBNZJO04"),
+            typeOfAmendment = Some(TypeOfAmendment.UploadDocuments)
+          ),
+          fileUploads = FileUploads(files =
+            Seq(
+              FileUpload.Accepted(
+                1,
+                "11370e18-6e24-453e-b45a-76d3e32ea33d",
+                "https://s3.amazonaws.com/bucket/123",
+                ZonedDateTime.parse("2018-04-24T09:30:00Z"),
+                "396f101dd52e8b2ace0dcf5ed09b1d1f030e608938510ce46e7a5c7a4e775100",
+                "test2.pdf",
+                "application/pdf"
+              ),
+              FileUpload.Accepted(
+                2,
+                "22370e18-6e24-453e-b45a-76d3e32ea33d",
+                "https://s3.amazonaws.com/bucket/123",
+                ZonedDateTime.parse("2018-04-24T09:30:00Z"),
+                "396f101dd52e8b2ace0dcf5ed09b1d1f030e608938510ce46e7a5c7a4e775100",
+                "test1.png",
+                "image/png"
+              )
+            )
+          )
+        )
+        journey.setState(state)
+        givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
+
+        val result = await(request("/add/file-uploaded/11370e18-6e24-453e-b45a-76d3e32ea33d/remove").put(""))
+
+        result.status shouldBe 204
+
+        journey.getState shouldBe UploadMultipleFiles(
+          AmendCaseModel(
+            caseReferenceNumber = Some("PC12010081330XGBNZJO04"),
+            typeOfAmendment = Some(TypeOfAmendment.UploadDocuments)
+          ),
+          fileUploads = FileUploads(files =
+            Seq(
+              FileUpload.Accepted(
+                2,
+                "22370e18-6e24-453e-b45a-76d3e32ea33d",
+                "https://s3.amazonaws.com/bucket/123",
+                ZonedDateTime.parse("2018-04-24T09:30:00Z"),
+                "396f101dd52e8b2ace0dcf5ed09b1d1f030e608938510ce46e7a5c7a4e775100",
+                "test1.png",
+                "image/png"
+              )
+            )
+          )
+        )
+      }
+    }
+
     "GET /add/confirmation" should {
       "show confirmation page" in {
         implicit val journeyId: JourneyId = JourneyId()

--- a/it/uk/gov/hmrc/traderservices/controllers/CreateCaseJourneyISpec.scala
+++ b/it/uk/gov/hmrc/traderservices/controllers/CreateCaseJourneyISpec.scala
@@ -2308,6 +2308,188 @@ class CreateCaseJourneyISpec extends CreateCaseJourneyISpecSetup with TraderServ
       }
     }
 
+    "GET /new/file-uploaded" should {
+      "show uploaded singular file view" in {
+        implicit val journeyId: JourneyId = JourneyId()
+        val dateTimeOfArrival = dateTime.plusDays(1).truncatedTo(ChronoUnit.MINUTES)
+        val state = FileUploaded(
+          FileUploadHostData(TestData.importDeclarationDetails, TestData.fullImportQuestions(dateTimeOfArrival)),
+          fileUploads = FileUploads(files =
+            Seq(
+              FileUpload.Accepted(
+                1,
+                "11370e18-6e24-453e-b45a-76d3e32ea33d",
+                "https://s3.amazonaws.com/bucket/123",
+                ZonedDateTime.parse("2018-04-24T09:30:00Z"),
+                "396f101dd52e8b2ace0dcf5ed09b1d1f030e608938510ce46e7a5c7a4e775100",
+                "test.pdf",
+                "application/pdf"
+              )
+            )
+          )
+        )
+        journey.setState(state)
+        givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
+
+        val result = await(request("/new/file-uploaded").get())
+
+        result.status shouldBe 200
+        result.body should include(htmlEscapedPageTitle("view.file-uploaded.singular.title", "1"))
+        result.body should include(htmlEscapedMessage("view.file-uploaded.singular.heading", "1"))
+        journey.getState shouldBe state
+      }
+
+      "show uploaded plural file view" in {
+        implicit val journeyId: JourneyId = JourneyId()
+        val dateTimeOfArrival = dateTime.plusDays(1).truncatedTo(ChronoUnit.MINUTES)
+        val state = FileUploaded(
+          FileUploadHostData(TestData.importDeclarationDetails, TestData.fullImportQuestions(dateTimeOfArrival)),
+          fileUploads = FileUploads(files =
+            Seq(
+              FileUpload.Accepted(
+                1,
+                "11370e18-6e24-453e-b45a-76d3e32ea33d",
+                "https://s3.amazonaws.com/bucket/123",
+                ZonedDateTime.parse("2018-04-24T09:30:00Z"),
+                "396f101dd52e8b2ace0dcf5ed09b1d1f030e608938510ce46e7a5c7a4e775100",
+                "test2.pdf",
+                "application/pdf"
+              ),
+              FileUpload.Accepted(
+                2,
+                "22370e18-6e24-453e-b45a-76d3e32ea33d",
+                "https://s3.amazonaws.com/bucket/123",
+                ZonedDateTime.parse("2018-04-24T09:30:00Z"),
+                "396f101dd52e8b2ace0dcf5ed09b1d1f030e608938510ce46e7a5c7a4e775100",
+                "test1.png",
+                "image/png"
+              )
+            )
+          )
+        )
+        journey.setState(state)
+        givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
+
+        val result = await(request("/new/file-uploaded").get())
+
+        result.status shouldBe 200
+        result.body should include(htmlEscapedPageTitle("view.file-uploaded.plural.title", "2"))
+        result.body should include(htmlEscapedMessage("view.file-uploaded.plural.heading", "2"))
+        journey.getState shouldBe state
+      }
+    }
+
+    "GET /new/file-uploaded/:reference/remove" should {
+      "remove file from upload list by reference" in {
+        implicit val journeyId: JourneyId = JourneyId()
+        val dateTimeOfArrival = dateTime.plusDays(1).truncatedTo(ChronoUnit.MINUTES)
+        val state = FileUploaded(
+          FileUploadHostData(TestData.importDeclarationDetails, TestData.fullImportQuestions(dateTimeOfArrival)),
+          fileUploads = FileUploads(files =
+            Seq(
+              FileUpload.Accepted(
+                1,
+                "11370e18-6e24-453e-b45a-76d3e32ea33d",
+                "https://s3.amazonaws.com/bucket/123",
+                ZonedDateTime.parse("2018-04-24T09:30:00Z"),
+                "396f101dd52e8b2ace0dcf5ed09b1d1f030e608938510ce46e7a5c7a4e775100",
+                "test2.pdf",
+                "application/pdf"
+              ),
+              FileUpload.Accepted(
+                2,
+                "22370e18-6e24-453e-b45a-76d3e32ea33d",
+                "https://s3.amazonaws.com/bucket/123",
+                ZonedDateTime.parse("2018-04-24T09:30:00Z"),
+                "396f101dd52e8b2ace0dcf5ed09b1d1f030e608938510ce46e7a5c7a4e775100",
+                "test1.png",
+                "image/png"
+              )
+            )
+          )
+        )
+        journey.setState(state)
+        givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
+
+        val result = await(request("/new/file-uploaded/11370e18-6e24-453e-b45a-76d3e32ea33d/remove").get())
+
+        result.status shouldBe 200
+        result.body should include(htmlEscapedPageTitle("view.file-uploaded.singular.title", "1"))
+        result.body should include(htmlEscapedMessage("view.file-uploaded.singular.heading", "1"))
+        journey.getState shouldBe FileUploaded(
+          FileUploadHostData(TestData.importDeclarationDetails, TestData.fullImportQuestions(dateTimeOfArrival)),
+          fileUploads = FileUploads(files =
+            Seq(
+              FileUpload.Accepted(
+                2,
+                "22370e18-6e24-453e-b45a-76d3e32ea33d",
+                "https://s3.amazonaws.com/bucket/123",
+                ZonedDateTime.parse("2018-04-24T09:30:00Z"),
+                "396f101dd52e8b2ace0dcf5ed09b1d1f030e608938510ce46e7a5c7a4e775100",
+                "test1.png",
+                "image/png"
+              )
+            )
+          )
+        )
+      }
+    }
+
+    "PUT /new/file-uploaded/:reference/remove" should {
+      "remove file from upload list by reference" in {
+        implicit val journeyId: JourneyId = JourneyId()
+        val dateTimeOfArrival = dateTime.plusDays(1).truncatedTo(ChronoUnit.MINUTES)
+        val state = UploadMultipleFiles(
+          FileUploadHostData(TestData.importDeclarationDetails, TestData.fullImportQuestions(dateTimeOfArrival)),
+          fileUploads = FileUploads(files =
+            Seq(
+              FileUpload.Accepted(
+                1,
+                "11370e18-6e24-453e-b45a-76d3e32ea33d",
+                "https://s3.amazonaws.com/bucket/123",
+                ZonedDateTime.parse("2018-04-24T09:30:00Z"),
+                "396f101dd52e8b2ace0dcf5ed09b1d1f030e608938510ce46e7a5c7a4e775100",
+                "test2.pdf",
+                "application/pdf"
+              ),
+              FileUpload.Accepted(
+                2,
+                "22370e18-6e24-453e-b45a-76d3e32ea33d",
+                "https://s3.amazonaws.com/bucket/123",
+                ZonedDateTime.parse("2018-04-24T09:30:00Z"),
+                "396f101dd52e8b2ace0dcf5ed09b1d1f030e608938510ce46e7a5c7a4e775100",
+                "test1.png",
+                "image/png"
+              )
+            )
+          )
+        )
+        journey.setState(state)
+        givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
+
+        val result = await(request("/new/file-uploaded/11370e18-6e24-453e-b45a-76d3e32ea33d/remove").put(""))
+
+        result.status shouldBe 204
+
+        journey.getState shouldBe UploadMultipleFiles(
+          FileUploadHostData(TestData.importDeclarationDetails, TestData.fullImportQuestions(dateTimeOfArrival)),
+          fileUploads = FileUploads(files =
+            Seq(
+              FileUpload.Accepted(
+                2,
+                "22370e18-6e24-453e-b45a-76d3e32ea33d",
+                "https://s3.amazonaws.com/bucket/123",
+                ZonedDateTime.parse("2018-04-24T09:30:00Z"),
+                "396f101dd52e8b2ace0dcf5ed09b1d1f030e608938510ce46e7a5c7a4e775100",
+                "test1.png",
+                "image/png"
+              )
+            )
+          )
+        )
+      }
+    }
+
     "GET /new/file-uploaded/:reference" should {
       "stream the uploaded file content back if exists" in {
         implicit val journeyId: JourneyId = JourneyId()

--- a/it/uk/gov/hmrc/traderservices/controllers/CreateCaseJourneyISpec.scala
+++ b/it/uk/gov/hmrc/traderservices/controllers/CreateCaseJourneyISpec.scala
@@ -1725,7 +1725,7 @@ class CreateCaseJourneyISpec extends CreateCaseJourneyISpecSetup with TraderServ
       }
     }
 
-    "GET /new/upload-multiple-files" should {
+    "GET /new/upload-files" should {
       "show the upload multiple files page for an importer" in {
         implicit val journeyId: JourneyId = JourneyId()
         val dateTimeOfArrival = dateTime.plusDays(1).truncatedTo(ChronoUnit.MINUTES)
@@ -1736,7 +1736,7 @@ class CreateCaseJourneyISpec extends CreateCaseJourneyISpecSetup with TraderServ
         journey.setState(state)
         givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
 
-        val result = await(request("/new/upload-multiple-files").get())
+        val result = await(request("/new/upload-files").get())
 
         result.status shouldBe 200
         result.body should include(htmlEscapedPageTitle("view.upload-multiple-files.title"))
@@ -1754,7 +1754,7 @@ class CreateCaseJourneyISpec extends CreateCaseJourneyISpecSetup with TraderServ
         journey.setState(state)
         givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
 
-        val result = await(request("/new/upload-multiple-files").get())
+        val result = await(request("/new/upload-files").get())
 
         result.status shouldBe 200
         result.body should include(htmlEscapedPageTitle("view.upload-multiple-files.title"))
@@ -1771,7 +1771,7 @@ class CreateCaseJourneyISpec extends CreateCaseJourneyISpecSetup with TraderServ
         journey.setState(state)
         givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
 
-        val result = await(request("/new/upload-multiple-files").get())
+        val result = await(request("/new/upload-files").get())
 
         result.status shouldBe 200
         result.body should include(htmlEscapedPageTitle("view.upload-multiple-files.title"))
@@ -1791,7 +1791,7 @@ class CreateCaseJourneyISpec extends CreateCaseJourneyISpecSetup with TraderServ
         journey.setState(state)
         givenAuthorisedForEnrolment(Enrolment("HMRC-XYZ", "EORINumber", "foo"))
 
-        val result = await(request("/new/upload-multiple-files").get())
+        val result = await(request("/new/upload-files").get())
 
         result.status shouldBe 200
         result.body should include(htmlEscapedPageTitle("view.upload-multiple-files.title"))
@@ -1803,7 +1803,7 @@ class CreateCaseJourneyISpec extends CreateCaseJourneyISpecSetup with TraderServ
       }
     }
 
-    "PUT /new/upload-multiple-files/initialise/:uploadId" should {
+    "PUT /new/upload-files/initialise/:uploadId" should {
       "initialise first file upload" in {
         implicit val journeyId: JourneyId = JourneyId()
         val dateTimeOfArrival = dateTime.plusDays(1).truncatedTo(ChronoUnit.MINUTES)
@@ -1817,7 +1817,7 @@ class CreateCaseJourneyISpec extends CreateCaseJourneyISpecSetup with TraderServ
           appConfig.baseInternalCallbackUrl + s"/send-documents-for-customs-check/new/journey/${journeyId.value}/callback-from-upscan"
         givenUpscanInitiateSucceeds(callbackUrl)
 
-        val result = await(request("/new/upload-multiple-files/initialise/001").put(""))
+        val result = await(request("/new/upload-files/initialise/001").put(""))
 
         result.status shouldBe 200
         val json = result.body[JsValue]
@@ -1888,7 +1888,7 @@ class CreateCaseJourneyISpec extends CreateCaseJourneyISpecSetup with TraderServ
           appConfig.baseInternalCallbackUrl + s"/send-documents-for-customs-check/new/journey/${journeyId.value}/callback-from-upscan"
         givenUpscanInitiateSucceeds(callbackUrl)
 
-        val result = await(request("/new/upload-multiple-files/initialise/002").put(""))
+        val result = await(request("/new/upload-files/initialise/002").put(""))
 
         result.status shouldBe 200
         val json = result.body[JsValue]

--- a/it/uk/gov/hmrc/traderservices/support/BaseISpec.scala
+++ b/it/uk/gov/hmrc/traderservices/support/BaseISpec.scala
@@ -19,6 +19,8 @@ abstract class BaseISpec
   import scala.concurrent.duration._
   override implicit val defaultTimeout: FiniteDuration = 5 seconds
 
+  val uploadMultipleFilesFeature: Boolean = false
+
   protected def appBuilder: GuiceApplicationBuilder =
     new GuiceApplicationBuilder()
       .configure(
@@ -29,7 +31,12 @@ abstract class BaseISpec
         "play.filters.csrf.method.whiteList.0" -> "POST",
         "play.filters.csrf.method.whiteList.1" -> "GET"
       )
-      .overrides(bind[AppConfig].toInstance(TestAppConfig(wireMockBaseUrlAsString, wireMockPort)))
+      .overrides(
+        bind[AppConfig]
+          .toInstance(
+            TestAppConfig(wireMockBaseUrlAsString, wireMockPort, uploadMultipleFilesFeature)
+          )
+      )
 
   override def commonStubs(): Unit = {
     givenCleanMetricRegistry()

--- a/it/uk/gov/hmrc/traderservices/support/BaseISpec.scala
+++ b/it/uk/gov/hmrc/traderservices/support/BaseISpec.scala
@@ -55,11 +55,13 @@ abstract class BaseISpec
   private lazy val messagesApi = app.injector.instanceOf[MessagesApi]
   private implicit val messages: Messages = messagesApi.preferred(Seq.empty[Lang])
 
-  final def htmlEscapedMessage(key: String): String = HtmlFormat.escape(Messages(key)).toString
-  final def htmlEscapedPageTitle(key: String): String =
-    htmlEscapedMessage(key) + " - " + htmlEscapedMessage("site.serviceName") + " - " + htmlEscapedMessage("site.govuk")
-  final def htmlEscapedPageTitleWithError(key: String): String =
-    htmlEscapedMessage("error.browser.title.prefix") + " " + htmlEscapedPageTitle(key)
+  final def htmlEscapedMessage(key: String, args: String*): String = HtmlFormat.escape(Messages(key, args: _*)).toString
+  final def htmlEscapedPageTitle(key: String, args: String*): String =
+    htmlEscapedMessage(key, args: _*) + " - " + htmlEscapedMessage("site.serviceName") + " - " + htmlEscapedMessage(
+      "site.govuk"
+    )
+  final def htmlEscapedPageTitleWithError(key: String, args: String*): String =
+    htmlEscapedMessage("error.browser.title.prefix", args: _*) + " " + htmlEscapedPageTitle(key)
 
   implicit def hc(implicit request: FakeRequest[_]): HeaderCarrier =
     HeaderCarrierConverter.fromHeadersAndSession(request.headers, Some(request.session))

--- a/it/uk/gov/hmrc/traderservices/support/TestAppConfig.scala
+++ b/it/uk/gov/hmrc/traderservices/support/TestAppConfig.scala
@@ -2,7 +2,8 @@ package uk.gov.hmrc.traderservices.support
 
 import uk.gov.hmrc.traderservices.wiring.AppConfig
 
-case class TestAppConfig(wireMockBaseUrl: String, wireMockPort: Int) extends AppConfig {
+case class TestAppConfig(wireMockBaseUrl: String, wireMockPort: Int, val uploadMultipleFilesFeature: Boolean)
+    extends AppConfig {
 
   override val appName: String = "trader-services-frontend"
   override val baseInternalCallbackUrl: String = s"http://baseInternalCallbackUrl"

--- a/test/uk/gov/hmrc/traderservices/controllers/FileUploadFormsSpec.scala
+++ b/test/uk/gov/hmrc/traderservices/controllers/FileUploadFormsSpec.scala
@@ -38,10 +38,14 @@ class FileUploadFormsSpec extends UnitSpec with FormValidator {
       validate(
         form,
         Map("key" -> "ABC-123", "bucket" -> "foo-bar-bucket"),
-        S3UploadSuccess(key = "ABC-123", bucket = "foo-bar-bucket")
+        S3UploadSuccess(key = "ABC-123", bucket = Some("foo-bar-bucket"))
       )
-      validateErrors(form, Map(), Seq("key" -> "error.required", "bucket" -> "error.required"))
-      validateErrors(form, Map("key" -> "123-ABC"), Seq("bucket" -> "error.required"))
+      validate(
+        form,
+        Map("key" -> "ABC-123"),
+        S3UploadSuccess(key = "ABC-123", bucket = None)
+      )
+      validateErrors(form, Map(), Seq("key" -> "error.required"))
     }
   }
 

--- a/test/uk/gov/hmrc/traderservices/controllers/FileUploadFormsSpec.scala
+++ b/test/uk/gov/hmrc/traderservices/controllers/FileUploadFormsSpec.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.traderservices.controllers
+
+import uk.gov.hmrc.traderservices.support.UnitSpec
+import uk.gov.hmrc.traderservices.models._
+import uk.gov.hmrc.traderservices.support.FormValidator
+
+class FileUploadFormsSpec extends UnitSpec with FormValidator {
+
+  "UploadAnotherFileChoiceForm" should {
+    "bind uploadAnotherFile choice and fill it back" in {
+      val form = CreateCaseJourneyController.UploadAnotherFileChoiceForm
+      validate(form, Map("uploadAnotherFile" -> "yes"), true)
+      validate(form, Map("uploadAnotherFile" -> "no"), false)
+      validate(form, "uploadAnotherFile", Map(), Seq("error.uploadAnotherFile.required"))
+      validate(form, "uploadAnotherFile", Map("uploadAnotherFile" -> "foo"), Seq("error.uploadAnotherFile.required"))
+    }
+  }
+
+  "UpscanUploadSuccessForm" should {
+    "bind S3 success query parameters" in {
+      val form = CreateCaseJourneyController.UpscanUploadSuccessForm
+      validate(
+        form,
+        Map("key" -> "ABC-123", "bucket" -> "foo-bar-bucket"),
+        S3UploadSuccess(key = "ABC-123", bucket = "foo-bar-bucket")
+      )
+      validateErrors(form, Map(), Seq("key" -> "error.required", "bucket" -> "error.required"))
+      validateErrors(form, Map("key" -> "123-ABC"), Seq("bucket" -> "error.required"))
+    }
+  }
+
+  "UpscanUploadErrorForm" should {
+    "bind S3 error query parameters" in {
+      val form = CreateCaseJourneyController.UpscanUploadErrorForm
+      validate(
+        form,
+        Map(
+          "key"            -> "ABC-123",
+          "errorCode"      -> "code-001",
+          "errorMessage"   -> "Strange file, is it?",
+          "errorRequestId" -> "0123456789",
+          "errorResource"  -> "/foo"
+        ),
+        S3UploadError(
+          key = "ABC-123",
+          errorCode = "code-001",
+          errorMessage = "Strange file, is it?",
+          errorRequestId = Some("0123456789"),
+          errorResource = Some("/foo")
+        )
+      )
+      validateErrors(
+        form,
+        Map(),
+        Seq("key" -> "error.required", "errorCode" -> "error.required", "errorMessage" -> "error.required")
+      )
+    }
+  }
+}

--- a/test/uk/gov/hmrc/traderservices/journey/AmendCaseJourneyModelSpec.scala
+++ b/test/uk/gov/hmrc/traderservices/journey/AmendCaseJourneyModelSpec.scala
@@ -39,33 +39,6 @@ class AmendCaseJourneyModelSpec extends UnitSpec with StateMatchers[State] with 
   // dummy journey context
   case class DummyContext()
   implicit val dummyContext: DummyContext = DummyContext()
-  val mockUpscanInitiate: UpscanInitiateApi = request =>
-    Future.successful(
-      UpscanInitiateResponse(
-        reference = "foo-bar-ref",
-        uploadRequest = UploadRequest(
-          href = "https://s3.bucket",
-          fields = Map(
-            "callbackUrl"         -> request.callbackUrl,
-            "successRedirect"     -> request.successRedirect.getOrElse(""),
-            "errorRedirect"       -> request.errorRedirect.getOrElse(""),
-            "minimumFileSize"     -> request.minimumFileSize.getOrElse(0).toString,
-            "maximumFileSize"     -> request.maximumFileSize.getOrElse(0).toString,
-            "expectedContentType" -> request.expectedContentType.getOrElse("")
-          )
-        )
-      )
-    )
-
-  val upscanRequest =
-    UpscanInitiateRequest(
-      callbackUrl = "https://foo.bar/callback",
-      successRedirect = Some("https://foo.bar/success"),
-      errorRedirect = Some("https://foo.bar/failure"),
-      minimumFileSize = Some(0),
-      maximumFileSize = Some(10 * 1024 * 1024),
-      expectedContentType = Some("image/jpeg,image/png")
-    )
 
   "AmendCaseJourneyModel" when {
     "at state Start" should {
@@ -109,7 +82,7 @@ class AmendCaseJourneyModelSpec extends UnitSpec with StateMatchers[State] with 
       "go to EnterResponseText when sumbited type of amendment WriteResponse" in {
         given(
           SelectTypeOfAmendment(AmendCaseModel(caseReferenceNumber = Some("PC12010081330XGBNZJO04")))
-        ) when submitedTypeOfAmendment(upscanRequest)(mockUpscanInitiate)(eoriNumber)(
+        ) when submitedTypeOfAmendment(testUpscanRequest)(mockUpscanInitiate)(eoriNumber)(
           TypeOfAmendment.WriteResponse
         ) should thenGo(
           EnterResponseText(
@@ -124,7 +97,7 @@ class AmendCaseJourneyModelSpec extends UnitSpec with StateMatchers[State] with 
       "go to EnterResponseText when sumbited type of amendment WriteResponseAndUploadDocuments" in {
         given(
           SelectTypeOfAmendment(AmendCaseModel(caseReferenceNumber = Some("PC12010081330XGBNZJO04")))
-        ) when submitedTypeOfAmendment(upscanRequest)(mockUpscanInitiate)(eoriNumber)(
+        ) when submitedTypeOfAmendment(testUpscanRequest)(mockUpscanInitiate)(eoriNumber)(
           TypeOfAmendment.WriteResponseAndUploadDocuments
         ) should thenGo(
           EnterResponseText(
@@ -139,7 +112,7 @@ class AmendCaseJourneyModelSpec extends UnitSpec with StateMatchers[State] with 
       "go to UploadFile when sumbited type of amendment UploadDocuments" in {
         given(
           SelectTypeOfAmendment(AmendCaseModel(caseReferenceNumber = Some("PC12010081330XGBNZJO04")))
-        ) when submitedTypeOfAmendment(upscanRequest)(mockUpscanInitiate)(eoriNumber)(
+        ) when submitedTypeOfAmendment(testUpscanRequest)(mockUpscanInitiate)(eoriNumber)(
           TypeOfAmendment.UploadDocuments
         ) should thenGo(
           UploadFile(

--- a/test/uk/gov/hmrc/traderservices/journey/AmendCaseJourneyModelSpec.scala
+++ b/test/uk/gov/hmrc/traderservices/journey/AmendCaseJourneyModelSpec.scala
@@ -157,7 +157,7 @@ class AmendCaseJourneyModelSpec extends UnitSpec with StateMatchers[State] with 
         )
         given(
           EnterResponseText(model)
-        ) when submitedResponseText(upscanRequest)(mockUpscanInitiate)(eoriNumber)(
+        ) when submitedResponseText(testUpscanRequest)(mockUpscanInitiate)(eoriNumber)(
           responseText
         ) should thenGo(AmendCaseSummary(model.copy(responseText = Some(responseText))))
       }
@@ -171,7 +171,7 @@ class AmendCaseJourneyModelSpec extends UnitSpec with StateMatchers[State] with 
               typeOfAmendment = Some(TypeOfAmendment.WriteResponse)
             )
           )
-        ) when submitedResponseText(upscanRequest)(mockUpscanInitiate)(eoriNumber)(
+        ) when submitedResponseText(testUpscanRequest)(mockUpscanInitiate)(eoriNumber)(
           responseText
         ) should thenGo(
           EnterCaseReferenceNumber(
@@ -193,7 +193,7 @@ class AmendCaseJourneyModelSpec extends UnitSpec with StateMatchers[State] with 
               typeOfAmendment = None
             )
           )
-        ) when submitedResponseText(upscanRequest)(mockUpscanInitiate)(eoriNumber)(
+        ) when submitedResponseText(testUpscanRequest)(mockUpscanInitiate)(eoriNumber)(
           responseText
         ) should thenGo(
           SelectTypeOfAmendment(
@@ -223,7 +223,7 @@ class AmendCaseJourneyModelSpec extends UnitSpec with StateMatchers[State] with 
               typeOfAmendment = Some(TypeOfAmendment.WriteResponseAndUploadDocuments)
             )
           )
-        ) when submitedResponseText(upscanRequest)(mockUpscanInitiate)(eoriNumber)(
+        ) when submitedResponseText(testUpscanRequest)(mockUpscanInitiate)(eoriNumber)(
           responseText
         ) should thenGo(
           UploadFile(
@@ -266,7 +266,7 @@ class AmendCaseJourneyModelSpec extends UnitSpec with StateMatchers[State] with 
               typeOfAmendment = Some(TypeOfAmendment.UploadDocuments)
             )
           )
-        ) shouldFailWhen submitedResponseText(upscanRequest)(mockUpscanInitiate)(eoriNumber)(
+        ) shouldFailWhen submitedResponseText(testUpscanRequest)(mockUpscanInitiate)(eoriNumber)(
           responseText
         )
       }

--- a/test/uk/gov/hmrc/traderservices/journey/AmendCaseJourneyModelSpec.scala
+++ b/test/uk/gov/hmrc/traderservices/journey/AmendCaseJourneyModelSpec.scala
@@ -464,7 +464,7 @@ class AmendCaseJourneyModelSpec extends UnitSpec with StateMatchers[State] with 
               )
             )
           )
-        ) when markUploadAsPosted(S3UploadSuccess("foo-bar-ref-2", "bucket-123")) should thenGo(
+        ) when markUploadAsPosted(S3UploadSuccess("foo-bar-ref-2", Some("bucket-123"))) should thenGo(
           UploadMultipleFiles(
             fullAmendCaseStateModel,
             FileUploads(files =
@@ -489,7 +489,7 @@ class AmendCaseJourneyModelSpec extends UnitSpec with StateMatchers[State] with 
             )
           )
         )
-        given(state) when markUploadAsPosted(S3UploadSuccess("foo-bar-ref-1", "bucket-123")) should thenGo(state)
+        given(state) when markUploadAsPosted(S3UploadSuccess("foo-bar-ref-1", Some("bucket-123"))) should thenGo(state)
       }
 
       "do nothing when markUploadAsPosted transition and already in ACCEPTED state" in {
@@ -512,7 +512,7 @@ class AmendCaseJourneyModelSpec extends UnitSpec with StateMatchers[State] with 
             )
           )
         )
-        given(state) when markUploadAsPosted(S3UploadSuccess("foo-bar-ref-4", "bucket-123")) should thenGo(state)
+        given(state) when markUploadAsPosted(S3UploadSuccess("foo-bar-ref-4", Some("bucket-123"))) should thenGo(state)
       }
 
       "do nothing when markUploadAsPosted transition and none matching upload exist" in {
@@ -526,7 +526,7 @@ class AmendCaseJourneyModelSpec extends UnitSpec with StateMatchers[State] with 
             )
           )
         )
-        given(state) when markUploadAsPosted(S3UploadSuccess("foo-bar-ref-4", "bucket-123")) should thenGo(state)
+        given(state) when markUploadAsPosted(S3UploadSuccess("foo-bar-ref-4", Some("bucket-123"))) should thenGo(state)
       }
 
       "mark file upload as REJECTED when markUploadAsRejected transition" in {

--- a/test/uk/gov/hmrc/traderservices/journey/AmendCaseJourneyModelSpec.scala
+++ b/test/uk/gov/hmrc/traderservices/journey/AmendCaseJourneyModelSpec.scala
@@ -670,7 +670,7 @@ class AmendCaseJourneyModelSpec extends UnitSpec with StateMatchers[State] with 
             FileUploads(files = Seq(FileUpload.Initiated(1, "foo-bar-ref-1")))
           )
 
-        given(state) when fileUploadWasRejected(eoriNumber)(
+        given(state) when markUploadAsRejected(eoriNumber)(
           S3UploadError(
             key = "foo-bar-ref-1",
             errorCode = "a",

--- a/test/uk/gov/hmrc/traderservices/journey/AmendCaseJourneyStateFormatsSpec.scala
+++ b/test/uk/gov/hmrc/traderservices/journey/AmendCaseJourneyStateFormatsSpec.scala
@@ -205,6 +205,42 @@ class AmendCaseJourneyStateFormatsSpec extends UnitSpec {
           )
         )
       )
+
+      validateJsonFormat(
+        s"""{"state":"UploadMultipleFiles","properties":{"hostData":{"caseReferenceNumber":"PC12010081330XGBNZJO04","typeOfAmendment":"WriteResponse","responseText":"$text"},
+           |"uploadRequestMap":{"foo1":{"href":"https://foo.bar","fields":{"amz":"123"}}},
+           |"fileUploads":{"files":[
+           |{"Initiated":{"orderNumber":1,"reference":"foo1"}},
+           |{"Accepted":{"orderNumber":4,"reference":"foo4","url":"https://bucketName.s3.eu-west-2.amazonaws.com?1235676",
+           |"uploadTimestamp":"2018-04-24T09:30:00Z","checksum":"396f101dd52e8b2ace0dcf5ed09b1d1f030e608938510ce46e7a5c7a4e775100","fileName":"test.pdf","fileMimeType":"application/pdf"}},
+           |{"Failed":{"orderNumber":2,"reference":"foo2","details":{"failureReason":"QUARANTINE","message":"some reason"}}},
+           |{"Posted":{"orderNumber":3,"reference":"foo3"}}
+           |]}}}""".stripMargin,
+        FileUploadState.UploadMultipleFiles(
+          fileUploadHostData,
+          Map(
+            "foo1" ->
+              UploadRequest(href = "https://foo.bar", fields = Map("amz" -> "123"))
+          ),
+          FileUploads(files =
+            Seq(
+              FileUpload.Initiated(1, "foo1"),
+              FileUpload.Accepted(
+                4,
+                "foo4",
+                "https://bucketName.s3.eu-west-2.amazonaws.com?1235676",
+                ZonedDateTime.parse("2018-04-24T09:30:00Z"),
+                "396f101dd52e8b2ace0dcf5ed09b1d1f030e608938510ce46e7a5c7a4e775100",
+                "test.pdf",
+                "application/pdf"
+              ),
+              FileUpload
+                .Failed(2, "foo2", UpscanNotification.FailureDetails(UpscanNotification.QUARANTINE, "some reason")),
+              FileUpload.Posted(3, "foo3")
+            )
+          )
+        )
+      )
     }
 
     "throw an exception when unknown state" in {

--- a/test/uk/gov/hmrc/traderservices/journey/AmendCaseJourneyStateFormatsSpec.scala
+++ b/test/uk/gov/hmrc/traderservices/journey/AmendCaseJourneyStateFormatsSpec.scala
@@ -208,9 +208,8 @@ class AmendCaseJourneyStateFormatsSpec extends UnitSpec {
 
       validateJsonFormat(
         s"""{"state":"UploadMultipleFiles","properties":{"hostData":{"caseReferenceNumber":"PC12010081330XGBNZJO04","typeOfAmendment":"WriteResponse","responseText":"$text"},
-           |"uploadRequestMap":{"foo1":{"href":"https://foo.bar","fields":{"amz":"123"}}},
            |"fileUploads":{"files":[
-           |{"Initiated":{"orderNumber":1,"reference":"foo1"}},
+           |{"Initiated":{"orderNumber":1,"reference":"foo1","uploadRequest":{"href":"https://foo.bar","fields":{"amz":"123"}},"uploadId":"aBc"}},
            |{"Accepted":{"orderNumber":4,"reference":"foo4","url":"https://bucketName.s3.eu-west-2.amazonaws.com?1235676",
            |"uploadTimestamp":"2018-04-24T09:30:00Z","checksum":"396f101dd52e8b2ace0dcf5ed09b1d1f030e608938510ce46e7a5c7a4e775100","fileName":"test.pdf","fileMimeType":"application/pdf"}},
            |{"Failed":{"orderNumber":2,"reference":"foo2","details":{"failureReason":"QUARANTINE","message":"some reason"}}},
@@ -218,13 +217,14 @@ class AmendCaseJourneyStateFormatsSpec extends UnitSpec {
            |]}}}""".stripMargin,
         FileUploadState.UploadMultipleFiles(
           fileUploadHostData,
-          Map(
-            "foo1" ->
-              UploadRequest(href = "https://foo.bar", fields = Map("amz" -> "123"))
-          ),
           FileUploads(files =
             Seq(
-              FileUpload.Initiated(1, "foo1"),
+              FileUpload.Initiated(
+                1,
+                "foo1",
+                uploadRequest = Some(UploadRequest(href = "https://foo.bar", fields = Map("amz" -> "123"))),
+                uploadId = Some("aBc")
+              ),
               FileUpload.Accepted(
                 4,
                 "foo4",

--- a/test/uk/gov/hmrc/traderservices/journey/CreateCaseJourneyModelSpec.scala
+++ b/test/uk/gov/hmrc/traderservices/journey/CreateCaseJourneyModelSpec.scala
@@ -862,7 +862,9 @@ class CreateCaseJourneyModelSpec extends UnitSpec with StateMatchers[State] with
               )
             )
           )
-        ) when submittedExportQuestionsContactInfo(upscanRequest)(mockUpscanInitiate)(eoriNumber)(
+        ) when submittedExportQuestionsContactInfo(uploadMultipleFiles = false)(upscanRequest)(mockUpscanInitiate)(
+          eoriNumber
+        )(
           ExportContactInfo(contactEmail = "name@somewhere.com")
         ) should thenGo(
           UploadFile(
@@ -917,7 +919,9 @@ class CreateCaseJourneyModelSpec extends UnitSpec with StateMatchers[State] with
               Some(nonEmptyFileUploads)
             )
           )
-        ) when submittedExportQuestionsContactInfo(upscanRequest)(mockUpscanInitiate)(eoriNumber)(
+        ) when submittedExportQuestionsContactInfo(uploadMultipleFiles = false)(upscanRequest)(mockUpscanInitiate)(
+          eoriNumber
+        )(
           ExportContactInfo(contactEmail = "name@somewhere.com")
         ) should thenGo(
           FileUploaded(
@@ -1546,7 +1550,9 @@ class CreateCaseJourneyModelSpec extends UnitSpec with StateMatchers[State] with
               )
             )
           )
-        ) when submittedImportQuestionsContactInfo(upscanRequest)(mockUpscanInitiate)(eoriNumber)(
+        ) when submittedImportQuestionsContactInfo(uploadMultipleFiles = false)(upscanRequest)(mockUpscanInitiate)(
+          eoriNumber
+        )(
           ImportContactInfo(contactEmail = "name@somewhere.com")
         ) should thenGo(
           UploadFile(
@@ -1601,7 +1607,9 @@ class CreateCaseJourneyModelSpec extends UnitSpec with StateMatchers[State] with
               Some(nonEmptyFileUploads)
             )
           )
-        ) when submittedImportQuestionsContactInfo(upscanRequest)(mockUpscanInitiate)(eoriNumber)(
+        ) when submittedImportQuestionsContactInfo(uploadMultipleFiles = false)(upscanRequest)(mockUpscanInitiate)(
+          eoriNumber
+        )(
           ImportContactInfo(contactEmail = "name@somewhere.com")
         ) should thenGo(
           FileUploaded(
@@ -2119,7 +2127,7 @@ class CreateCaseJourneyModelSpec extends UnitSpec with StateMatchers[State] with
             FileUploads(files = Seq(FileUpload.Initiated(1, "foo-bar-ref-1")))
           )
 
-        given(state) when fileUploadWasRejected(eoriNumber)(
+        given(state) when markUploadAsRejected(eoriNumber)(
           S3UploadError(
             key = "foo-bar-ref-1",
             errorCode = "a",

--- a/test/uk/gov/hmrc/traderservices/journey/CreateCaseJourneyModelSpec.scala
+++ b/test/uk/gov/hmrc/traderservices/journey/CreateCaseJourneyModelSpec.scala
@@ -1974,7 +1974,7 @@ class CreateCaseJourneyModelSpec extends UnitSpec with StateMatchers[State] with
               )
             )
           )
-        ) when markUploadAsPosted(S3UploadSuccess("foo-bar-ref-2", "bucket-123")) should thenGo(
+        ) when markUploadAsPosted(S3UploadSuccess("foo-bar-ref-2", Some("bucket-123"))) should thenGo(
           UploadMultipleFiles(
             FileUploadHostData(exportDeclarationDetails, completeExportQuestionsAnswers),
             FileUploads(files =
@@ -1999,7 +1999,7 @@ class CreateCaseJourneyModelSpec extends UnitSpec with StateMatchers[State] with
             )
           )
         )
-        given(state) when markUploadAsPosted(S3UploadSuccess("foo-bar-ref-1", "bucket-123")) should thenGo(state)
+        given(state) when markUploadAsPosted(S3UploadSuccess("foo-bar-ref-1", Some("bucket-123"))) should thenGo(state)
       }
 
       "do nothing when markUploadAsPosted transition and already in ACCEPTED state" in {
@@ -2022,7 +2022,7 @@ class CreateCaseJourneyModelSpec extends UnitSpec with StateMatchers[State] with
             )
           )
         )
-        given(state) when markUploadAsPosted(S3UploadSuccess("foo-bar-ref-4", "bucket-123")) should thenGo(state)
+        given(state) when markUploadAsPosted(S3UploadSuccess("foo-bar-ref-4", Some("bucket-123"))) should thenGo(state)
       }
 
       "do nothing when markUploadAsPosted transition and none matching upload exist" in {
@@ -2036,7 +2036,7 @@ class CreateCaseJourneyModelSpec extends UnitSpec with StateMatchers[State] with
             )
           )
         )
-        given(state) when markUploadAsPosted(S3UploadSuccess("foo-bar-ref-4", "bucket-123")) should thenGo(state)
+        given(state) when markUploadAsPosted(S3UploadSuccess("foo-bar-ref-4", Some("bucket-123"))) should thenGo(state)
       }
 
       "mark file upload as REJECTED when markUploadAsRejected transition" in {

--- a/test/uk/gov/hmrc/traderservices/journey/CreateCaseJourneyStateFormatsSpec.scala
+++ b/test/uk/gov/hmrc/traderservices/journey/CreateCaseJourneyStateFormatsSpec.scala
@@ -574,6 +574,48 @@ class CreateCaseJourneyStateFormatsSpec extends UnitSpec {
       )
 
       validateJsonFormat(
+        """{"state":"UploadMultipleFiles","properties":{"hostData":{"declarationDetails":{"epu":"123","entryNumber":"000000Z","entryDate":"2020-10-05"},
+          |"questionsAnswers":{"export":{"requestType":"New","routeType":"Route2","hasPriorityGoods":false,"freightType":"Air",
+          |"vesselDetails":{"vesselName":"Foo Bar","dateOfArrival":"2020-10-19","timeOfArrival":"10:09:00"},
+          |"contactInfo":{"contactName":"Bob","contactEmail":"name@somewhere.com","contactNumber":"012345678910"}}}},
+          |"uploadRequestMap":{"foo1":{"href":"https://foo.bar","fields":{"amz":"123"}}},
+          |"fileUploads":{"files":[
+          |{"Initiated":{"orderNumber":1,"reference":"foo1"}},
+          |{"Accepted":{"orderNumber":4,"reference":"foo4","url":"https://bucketName.s3.eu-west-2.amazonaws.com?1235676",
+          |"uploadTimestamp":"2018-04-24T09:30:00Z","checksum":"396f101dd52e8b2ace0dcf5ed09b1d1f030e608938510ce46e7a5c7a4e775100","fileName":"test.pdf","fileMimeType":"application/pdf"}},
+          |{"Failed":{"orderNumber":2,"reference":"foo2","details":{"failureReason":"QUARANTINE","message":"some reason"}}},
+          |{"Posted":{"orderNumber":3,"reference":"foo3"}}
+          |]}}}""".stripMargin,
+        FileUploadState.UploadMultipleFiles(
+          FileUploadHostData(
+            DeclarationDetails(EPU(123), EntryNumber("000000Z"), LocalDate.parse("2020-10-05")),
+            exportQuestions
+          ),
+          Map(
+            "foo1" ->
+              UploadRequest(href = "https://foo.bar", fields = Map("amz" -> "123"))
+          ),
+          FileUploads(files =
+            Seq(
+              FileUpload.Initiated(1, "foo1"),
+              FileUpload.Accepted(
+                4,
+                "foo4",
+                "https://bucketName.s3.eu-west-2.amazonaws.com?1235676",
+                ZonedDateTime.parse("2018-04-24T09:30:00Z"),
+                "396f101dd52e8b2ace0dcf5ed09b1d1f030e608938510ce46e7a5c7a4e775100",
+                "test.pdf",
+                "application/pdf"
+              ),
+              FileUpload
+                .Failed(2, "foo2", UpscanNotification.FailureDetails(UpscanNotification.QUARANTINE, "some reason")),
+              FileUpload.Posted(3, "foo3")
+            )
+          )
+        )
+      )
+
+      validateJsonFormat(
         s"""{"state":"CreateCaseConfirmation","properties":{"declarationDetails":{"epu":"123","entryNumber":"000000Z","entryDate":"2020-10-05"},
            |"questionsAnswers":{"export":{"requestType":"New","routeType":"Route2","hasPriorityGoods":false,"freightType":"Air",
            |"vesselDetails":{"vesselName":"Foo Bar","dateOfArrival":"2020-10-19","timeOfArrival":"10:09:00"},

--- a/test/uk/gov/hmrc/traderservices/journey/CreateCaseJourneyStateFormatsSpec.scala
+++ b/test/uk/gov/hmrc/traderservices/journey/CreateCaseJourneyStateFormatsSpec.scala
@@ -578,9 +578,8 @@ class CreateCaseJourneyStateFormatsSpec extends UnitSpec {
           |"questionsAnswers":{"export":{"requestType":"New","routeType":"Route2","hasPriorityGoods":false,"freightType":"Air",
           |"vesselDetails":{"vesselName":"Foo Bar","dateOfArrival":"2020-10-19","timeOfArrival":"10:09:00"},
           |"contactInfo":{"contactName":"Bob","contactEmail":"name@somewhere.com","contactNumber":"012345678910"}}}},
-          |"uploadRequestMap":{"foo1":{"href":"https://foo.bar","fields":{"amz":"123"}}},
           |"fileUploads":{"files":[
-          |{"Initiated":{"orderNumber":1,"reference":"foo1"}},
+          |{"Initiated":{"orderNumber":1,"reference":"foo1","uploadRequest":{"href":"https://foo.bar","fields":{"amz":"123"}},"uploadId":"001"}},
           |{"Accepted":{"orderNumber":4,"reference":"foo4","url":"https://bucketName.s3.eu-west-2.amazonaws.com?1235676",
           |"uploadTimestamp":"2018-04-24T09:30:00Z","checksum":"396f101dd52e8b2ace0dcf5ed09b1d1f030e608938510ce46e7a5c7a4e775100","fileName":"test.pdf","fileMimeType":"application/pdf"}},
           |{"Failed":{"orderNumber":2,"reference":"foo2","details":{"failureReason":"QUARANTINE","message":"some reason"}}},
@@ -591,13 +590,15 @@ class CreateCaseJourneyStateFormatsSpec extends UnitSpec {
             DeclarationDetails(EPU(123), EntryNumber("000000Z"), LocalDate.parse("2020-10-05")),
             exportQuestions
           ),
-          Map(
-            "foo1" ->
-              UploadRequest(href = "https://foo.bar", fields = Map("amz" -> "123"))
-          ),
           FileUploads(files =
             Seq(
-              FileUpload.Initiated(1, "foo1"),
+              FileUpload
+                .Initiated(
+                  orderNumber = 1,
+                  reference = "foo1",
+                  uploadRequest = Some(UploadRequest(href = "https://foo.bar", fields = Map("amz" -> "123"))),
+                  uploadId = Some("001")
+                ),
               FileUpload.Accepted(
                 4,
                 "foo4",

--- a/test/uk/gov/hmrc/traderservices/journey/TestData.scala
+++ b/test/uk/gov/hmrc/traderservices/journey/TestData.scala
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.traderservices.journey
+
+import uk.gov.hmrc.traderservices.models._
+import java.time._
+import scala.concurrent.Future
+import uk.gov.hmrc.traderservices.connectors._
+import uk.gov.hmrc.traderservices.journeys.CreateCaseJourneyModel.UpscanInitiateApi
+
+trait TestData {
+
+  val eoriNumber = "foo"
+  val correlationId = "123"
+  val generatedAt = java.time.LocalDateTime.of(2018, 12, 11, 10, 20, 0)
+
+  val exportDeclarationDetails = DeclarationDetails(EPU(123), EntryNumber("Z00000Z"), LocalDate.parse("2020-09-23"))
+  val importDeclarationDetails = DeclarationDetails(EPU(123), EntryNumber("000000Z"), LocalDate.parse("2020-09-23"))
+  val invalidDeclarationDetails = DeclarationDetails(EPU(123), EntryNumber("0000000"), LocalDate.parse("2020-09-23"))
+
+  val completeExportQuestionsAnswers = ExportQuestions(
+    requestType = Some(ExportRequestType.New),
+    routeType = Some(ExportRouteType.Route3),
+    hasPriorityGoods = Some(true),
+    priorityGoods = Some(ExportPriorityGoods.ExplosivesOrFireworks),
+    freightType = Some(ExportFreightType.Air),
+    vesselDetails =
+      Some(VesselDetails(Some("Foo"), Some(LocalDate.parse("2021-01-01")), Some(LocalTime.parse("00:00")))),
+    contactInfo = Some(ExportContactInfo(contactEmail = "name@somewhere.com"))
+  )
+
+  val completeImportQuestionsAnswers = ImportQuestions(
+    requestType = Some(ImportRequestType.New),
+    routeType = Some(ImportRouteType.Route3),
+    hasPriorityGoods = Some(true),
+    priorityGoods = Some(ImportPriorityGoods.ExplosivesOrFireworks),
+    hasALVS = Some(true),
+    freightType = Some(ImportFreightType.Air),
+    vesselDetails =
+      Some(VesselDetails(Some("Foo"), Some(LocalDate.parse("2021-01-01")), Some(LocalTime.parse("00:00")))),
+    contactInfo = Some(ImportContactInfo(contactEmail = "name@somewhere.com"))
+  )
+
+  val nonEmptyFileUploads = FileUploads(files =
+    Seq(
+      FileUpload.Accepted(
+        1,
+        "foo-bar-ref-1",
+        "https://bucketName.s3.eu-west-2.amazonaws.com?1235676",
+        ZonedDateTime.parse("2018-04-24T09:30:00Z"),
+        "396f101dd52e8b2ace0dcf5ed09b1d1f030e608938510ce46e7a5c7a4e775100",
+        "test.pdf",
+        "application/pdf"
+      )
+    )
+  )
+
+  val mockUpscanInitiate: UpscanInitiateApi = request =>
+    Future.successful(
+      UpscanInitiateResponse(
+        reference = "foo-bar-ref",
+        uploadRequest = someUploadRequest(request)
+      )
+    )
+
+  val testUpscanRequest =
+    UpscanInitiateRequest(
+      callbackUrl = "https://foo.bar/callback",
+      successRedirect = Some("https://foo.bar/success"),
+      errorRedirect = Some("https://foo.bar/failure"),
+      minimumFileSize = Some(0),
+      maximumFileSize = Some(10 * 1024 * 1024),
+      expectedContentType = Some("image/jpeg,image/png")
+    )
+
+  def someUploadRequest(request: UpscanInitiateRequest) =
+    UploadRequest(
+      href = "https://s3.bucket",
+      fields = Map(
+        "callbackUrl"         -> request.callbackUrl,
+        "successRedirect"     -> request.successRedirect.getOrElse(""),
+        "errorRedirect"       -> request.errorRedirect.getOrElse(""),
+        "minimumFileSize"     -> request.minimumFileSize.getOrElse(0).toString,
+        "maximumFileSize"     -> request.maximumFileSize.getOrElse(0).toString,
+        "expectedContentType" -> request.expectedContentType.getOrElse("")
+      )
+    )
+
+}

--- a/test/uk/gov/hmrc/traderservices/support/FormValidator.scala
+++ b/test/uk/gov/hmrc/traderservices/support/FormValidator.scala
@@ -43,4 +43,9 @@ trait FormValidator extends FormMatchers {
     form.bind(formInput).errors should haveOnlyErrors(errors.map(e => FormError(fieldName, e)): _*)
     form.bind(formInput).value shouldBe None
   }
+
+  def validateErrors[A](form: Form[A], formInput: Map[String, String], errors: Seq[(String, String)]): Unit = {
+    form.bind(formInput).errors should haveOnlyErrors(errors.map { case (k, e) => FormError(k, e) }: _*)
+    form.bind(formInput).value shouldBe None
+  }
 }


### PR DESCRIPTION
This PR introduces new state, actions and view to support new feature of uploading multiple files on a single page. This feature depends on the new config property `features.uploadMultipleFiles`, initially set to false. Merging this PR will not change any of the current journeys, but will enable seamless upcoming refactorings.