### PR TITLE
[AO] upgrade depedencies and plugins, switch to bas-gateway-frontend

### DIFF
--- a/app/uk/gov/hmrc/traderservices/views/viewmodels/TimeInput.scala
+++ b/app/uk/gov/hmrc/traderservices/views/viewmodels/TimeInput.scala
@@ -20,7 +20,6 @@ import play.api.libs.functional.syntax._
 import play.api.libs.json._
 import uk.gov.hmrc.govukfrontend.views.html.components._
 import uk.gov.hmrc.govukfrontend.views.viewmodels.CommonJsonFormats._
-import uk.gov.hmrc.govukfrontend.views.viewmodels.JsonDefaultValueFormatter
 
 case class TimeInput(
   id: String = "",
@@ -36,26 +35,26 @@ case class TimeInput(
   showSelectPeriod: Boolean = true
 )
 
-object TimeInput extends JsonDefaultValueFormatter[TimeInput] {
+object TimeInput {
 
-  override def defaultObject: TimeInput = TimeInput()
+  def defaultObject: TimeInput = TimeInput()
 
-  override def defaultReads: Reads[TimeInput] =
+  implicit def jsonReads: Reads[TimeInput] =
     (
-      (__ \ "id").read[String] and
+      (__ \ "id").readWithDefault[String](defaultObject.id) and
         (__ \ "namePrefix").readNullable[String] and
-        (__ \ "items").read[Seq[InputItem]] and
-        (__ \ "periodSelectItems").read[Seq[SelectItem]] and
+        (__ \ "items").readWithDefault[Seq[InputItem]](defaultObject.items) and
+        (__ \ "periodSelectItems").readWithDefault[Seq[SelectItem]](defaultObject.periodSelectItems) and
         (__ \ "hint").readNullable[Hint] and
         (__ \ "errorMessage").readNullable[ErrorMessage] and
         readsFormGroupClasses and
         (__ \ "fieldset").readNullable[Fieldset] and
-        (__ \ "classes").read[String] and
-        (__ \ "attributes").read[Map[String, String]] and
-        (__ \ "showSelectPeriod").read[Boolean]
+        (__ \ "classes").readWithDefault[String](defaultObject.classes) and
+        (__ \ "attributes").readWithDefault[Map[String, String]](defaultObject.attributes) and
+        (__ \ "showSelectPeriod").readWithDefault[Boolean](defaultObject.showSelectPeriod)
     )(TimeInput.apply _)
 
-  override implicit def jsonWrites: OWrites[TimeInput] =
+  implicit def jsonWrites: OWrites[TimeInput] =
     (
       (__ \ "id").write[String] and
         (__ \ "namePrefix").writeNullable[String] and

--- a/build.sbt
+++ b/build.sbt
@@ -16,15 +16,15 @@ lazy val scoverageSettings = {
 }
 
 lazy val compileDeps = Seq(
-  "uk.gov.hmrc"                  %% "bootstrap-frontend-play-27" % "3.2.0",
+  "uk.gov.hmrc"                  %% "bootstrap-frontend-play-27" % "3.3.0",
   "uk.gov.hmrc"                  %% "auth-client"                % "3.2.0-play-27",
   "uk.gov.hmrc"                  %% "play-fsm"                   % "0.71.0-play-27",
   "uk.gov.hmrc"                  %% "domain"                     % "5.10.0-play-27",
   "uk.gov.hmrc"                  %% "mongo-caching"              % "6.16.0-play-27",
   "uk.gov.hmrc"                  %% "json-encryption"            % "4.8.0-play-27",
-  "uk.gov.hmrc"                  %% "play-frontend-govuk"        % "0.56.0-play-27",
-  "uk.gov.hmrc"                  %% "play-frontend-hmrc"         % "0.34.0-play-27",
-  "com.googlecode.libphonenumber" % "libphonenumber"             % "8.12.14",
+  "uk.gov.hmrc"                  %% "play-frontend-govuk"        % "0.60.0-play-27",
+  "uk.gov.hmrc"                  %% "play-frontend-hmrc"         % "0.38.0-play-27",
+  "com.googlecode.libphonenumber" % "libphonenumber"             % "8.12.16",
   "com.sun.mail"                  % "javax.mail"                 % "1.6.2"
 )
 
@@ -93,7 +93,7 @@ lazy val root = (project in file("."))
     scalafmtOnCompile in IntegrationTest := true
   )
   .disablePlugins(JUnitXmlReportPlugin) //Required to prevent https://github.com/scalatest/scalatest/issues/1427
-  .enablePlugins(PlayScala, SbtAutoBuildPlugin, SbtGitVersioning, SbtDistributablesPlugin, SbtArtifactory)
+  .enablePlugins(PlayScala, SbtAutoBuildPlugin, SbtGitVersioning, SbtDistributablesPlugin)
 
 inConfig(IntegrationTest)(org.scalafmt.sbt.ScalafmtPlugin.scalafmtConfigSettings)
 

--- a/it/uk/gov/hmrc/traderservices/controllers/AuthActionsISpec.scala
+++ b/it/uk/gov/hmrc/traderservices/controllers/AuthActionsISpec.scala
@@ -67,7 +67,9 @@ class AuthActionsISpec extends AuthActionISpecSetup {
       givenRequestIsNotAuthorised("IncorrectCredentialStrength")
       val result = TestController.withAuthorisedEnrolment("serviceName", "serviceKey")
       status(result) shouldBe 303
-      redirectLocation(result).get should include("/gg/sign-in")
+      redirectLocation(result).get should include(
+        "/bas-gateway/sign-in?continue_url=%2F&origin=trader-services-route-one-frontend"
+      )
     }
   }
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,17 +3,15 @@ resolvers += Resolver.url("HMRC Sbt Plugin Releases", url("https://dl.bintray.co
 )
 resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.10.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.13.0")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.7")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.0.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.2.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.5.0")
-
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
 


### PR DESCRIPTION
This PR upgrades, amongst others, `bootstrap-frontend-play-27` to version `3.3.0`, where the default auth sign-in has been changed from `company-auth-frontend` to the `base-gateway-frontend`, hence it can be only tested with `agents-external-stubs-frontend` version >= `0.128.0`.