### PR TITLE
[AO] migrate journey cache from reactive-mongo to hmrc-mongo

### DIFF
--- a/app/FrontendModule.scala
+++ b/app/FrontendModule.scala
@@ -17,12 +17,12 @@
 import com.google.inject.AbstractModule
 import play.api.{Configuration, Environment, Logger}
 import uk.gov.hmrc.auth.core.AuthConnector
-import uk.gov.hmrc.cache.repository.CacheMongoRepository
 import uk.gov.hmrc.traderservices.connectors.FrontendAuthConnector
 import uk.gov.hmrc.traderservices.services._
-import uk.gov.hmrc.traderservices.repository.JourneyCacheRepository
 import uk.gov.hmrc.http._
 import uk.gov.hmrc.play.bootstrap.http.DefaultHttpClient
+import uk.gov.hmrc.traderservices.repository.JourneyCacheRepository
+import uk.gov.hmrc.traderservices.repository.CacheRepository
 
 class FrontendModule(val environment: Environment, val configuration: Configuration) extends AbstractModule {
 
@@ -37,7 +37,7 @@ class FrontendModule(val environment: Environment, val configuration: Configurat
 
     bind(classOf[AuthConnector]).to(classOf[FrontendAuthConnector])
 
-    bind(classOf[CacheMongoRepository]).to(classOf[JourneyCacheRepository])
+    bind(classOf[CacheRepository]).to(classOf[JourneyCacheRepository])
 
     bind(classOf[CreateCaseJourneyServiceWithHeaderCarrier])
       .to(classOf[MongoDBCachedCreateCaseJourneyService])

--- a/app/uk/gov/hmrc/traderservices/repository/CacheRepository.scala
+++ b/app/uk/gov/hmrc/traderservices/repository/CacheRepository.scala
@@ -16,24 +16,24 @@
 
 package uk.gov.hmrc.traderservices.repository
 
-import javax.inject.{Inject, Singleton}
-import uk.gov.hmrc.traderservices.wiring.AppConfig
-
-import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.Duration
 import uk.gov.hmrc.mongo.MongoComponent
-import play.api.Configuration
 import uk.gov.hmrc.mongo.TimestampSupport
+import uk.gov.hmrc.mongo.cache.MongoCacheRepository
+import uk.gov.hmrc.mongo.cache.CacheIdType
+import scala.concurrent.ExecutionContext
 
-@Singleton
-class JourneyCacheRepository @Inject() (
+class CacheRepository(
   mongoComponent: MongoComponent,
-  configuration: Configuration,
-  timestampSupport: TimestampSupport,
-  appConfig: AppConfig
+  collectionName: String,
+  ttl: Duration,
+  timestampSupport: TimestampSupport
 )(implicit ec: ExecutionContext)
-    extends CacheRepository(
+    extends MongoCacheRepository[String](
       mongoComponent = mongoComponent,
-      collectionName = "fsm-journeys",
-      ttl = appConfig.mongoSessionExpiration,
-      timestampSupport = timestampSupport
-    )
+      collectionName = collectionName,
+      replaceIndexes = true,
+      ttl = ttl,
+      timestampSupport = timestampSupport,
+      cacheIdType = CacheIdType.SimpleCacheId
+    )(ec)

--- a/app/uk/gov/hmrc/traderservices/services/AmendCaseJourneyService.scala
+++ b/app/uk/gov/hmrc/traderservices/services/AmendCaseJourneyService.scala
@@ -18,12 +18,12 @@ package uk.gov.hmrc.traderservices.services
 
 import javax.inject.{Inject, Singleton}
 import play.api.libs.json.Format
-import uk.gov.hmrc.cache.repository.CacheMongoRepository
 import uk.gov.hmrc.crypto.ApplicationCrypto
 import uk.gov.hmrc.traderservices.journeys.{AmendCaseJourneyModel, AmendCaseJourneyStateFormats}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.fsm.PersistentJourneyService
 import uk.gov.hmrc.traderservices.wiring.AppConfig
+import uk.gov.hmrc.traderservices.repository.CacheRepository
 
 trait AmendCaseJourneyService[RequestContext] extends PersistentJourneyService[RequestContext] {
 
@@ -41,7 +41,7 @@ trait AmendCaseJourneyServiceWithHeaderCarrier extends AmendCaseJourneyService[H
 
 @Singleton
 case class MongoDBCachedAmendCaseJourneyService @Inject() (
-  cacheMongoRepository: CacheMongoRepository,
+  cacheMongoRepository: CacheRepository,
   applicationCrypto: ApplicationCrypto,
   appConfig: AppConfig
 ) extends MongoDBCachedJourneyService[HeaderCarrier] with AmendCaseJourneyServiceWithHeaderCarrier {

--- a/app/uk/gov/hmrc/traderservices/services/CreateCaseJourneyService.scala
+++ b/app/uk/gov/hmrc/traderservices/services/CreateCaseJourneyService.scala
@@ -18,12 +18,12 @@ package uk.gov.hmrc.traderservices.services
 
 import javax.inject.{Inject, Singleton}
 import play.api.libs.json.Format
-import uk.gov.hmrc.cache.repository.CacheMongoRepository
 import uk.gov.hmrc.crypto.ApplicationCrypto
 import uk.gov.hmrc.traderservices.journeys.{CreateCaseJourneyModel, CreateCaseJourneyStateFormats}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.fsm.PersistentJourneyService
 import uk.gov.hmrc.traderservices.wiring.AppConfig
+import uk.gov.hmrc.traderservices.repository.CacheRepository
 
 trait CreateCaseJourneyService[RequestContext] extends PersistentJourneyService[RequestContext] {
 
@@ -41,7 +41,7 @@ trait CreateCaseJourneyServiceWithHeaderCarrier extends CreateCaseJourneyService
 
 @Singleton
 case class MongoDBCachedCreateCaseJourneyService @Inject() (
-  cacheMongoRepository: CacheMongoRepository,
+  cacheMongoRepository: CacheRepository,
   applicationCrypto: ApplicationCrypto,
   appConfig: AppConfig
 ) extends MongoDBCachedJourneyService[HeaderCarrier] with CreateCaseJourneyServiceWithHeaderCarrier {

--- a/app/uk/gov/hmrc/traderservices/services/MongoDBCachedJourneyService.scala
+++ b/app/uk/gov/hmrc/traderservices/services/MongoDBCachedJourneyService.scala
@@ -17,12 +17,12 @@
 package uk.gov.hmrc.traderservices.services
 
 import play.api.libs.json.{Format, Json}
-import uk.gov.hmrc.cache.repository.{CacheMongoRepository, CacheRepository}
 import uk.gov.hmrc.crypto.json.{JsonDecryptor, JsonEncryptor}
 import uk.gov.hmrc.crypto.{ApplicationCrypto, CompositeSymmetricCrypto, Protected}
 import uk.gov.hmrc.play.fsm.PersistentJourneyService
 
 import scala.concurrent.{ExecutionContext, Future}
+import uk.gov.hmrc.traderservices.repository.CacheRepository
 
 /**
   * Journey persistence service mixin,
@@ -30,7 +30,7 @@ import scala.concurrent.{ExecutionContext, Future}
   */
 trait MongoDBCachedJourneyService[RequestContext] extends PersistentJourneyService[RequestContext] {
 
-  val cacheMongoRepository: CacheMongoRepository
+  val cacheMongoRepository: CacheRepository
   val applicationCrypto: ApplicationCrypto
   val stateFormats: Format[model.State]
   def getJourneyId(context: RequestContext): Option[String]

--- a/app/uk/gov/hmrc/traderservices/wiring/AppConfig.scala
+++ b/app/uk/gov/hmrc/traderservices/wiring/AppConfig.scala
@@ -23,6 +23,7 @@ import uk.gov.hmrc.play.bootstrap.binders.SafeRedirectUrl
 import play.api.i18n.Lang
 import play.api.mvc.{Call, RequestHeader}
 import scala.util.Try
+import scala.concurrent.duration.Duration
 
 object AppConfig {
   val vesselArrivalConstraintMonths = 6
@@ -45,7 +46,8 @@ trait AppConfig {
   val createCaseApiPath: String
   val updateCaseApiPath: String
 
-  val mongoSessionExpiryTime: Int
+  val mongoSessionExpiration: Duration
+
   val authorisedServiceName: String
   val authorisedIdentifierKey: String
   val subscriptionJourneyUrl: String
@@ -114,7 +116,7 @@ class AppConfigImpl @Inject() (config: ServicesConfig) extends AppConfig {
       )
     )
 
-  override val mongoSessionExpiryTime: Int = config.getInt("mongodb.session.expireAfterSeconds")
+  override val mongoSessionExpiration: Duration = config.getDuration("mongodb.session.expiration")
 
   override val authorisedServiceName: String = config.getString("authorisedServiceName")
   override val authorisedIdentifierKey: String = config.getString("authorisedIdentifierKey")

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ lazy val compileDeps = Seq(
   "uk.gov.hmrc"                  %% "auth-client"                % "4.0.0-play-27",
   "uk.gov.hmrc"                  %% "play-fsm"                   % "0.83.0-play-27",
   "uk.gov.hmrc"                  %% "domain"                     % "5.10.0-play-27",
-  "uk.gov.hmrc"                  %% "mongo-caching"              % "6.16.0-play-27",
+  "uk.gov.hmrc.mongo"            %% "hmrc-mongo-play-27"         % "0.47.0",
   "uk.gov.hmrc"                  %% "json-encryption"            % "4.8.0-play-27",
   "uk.gov.hmrc"                  %% "play-frontend-govuk"        % "0.65.0-play-27",
   "uk.gov.hmrc"                  %% "play-frontend-hmrc"         % "0.49.0-play-27",

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -31,6 +31,8 @@ play.modules.enabled += "uk.gov.hmrc.play.bootstrap.graphite.GraphiteMetricsModu
 # Provides an implementation and configures all filters required by a Platform frontend microservice.
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.frontend.FrontendModule"
 
+play.modules.enabled += "uk.gov.hmrc.mongo.play.PlayMongoModule"
+
 # Custom error handler
 play.http.errorHandler = "uk.gov.hmrc.traderservices.wiring.ErrorHandler"
 
@@ -156,7 +158,7 @@ mongo-async-driver {
 
 mongodb {
   uri = "mongodb://localhost:27017/trader-services-frontend?rm.monitorRefreshMS=1000&rm.failover=default"
-  session.expireAfterSeconds = 3600 //1 hour
+  session.expiration = 1 hour
 }
 
 host = "http://localhost:9379"

--- a/it/uk/gov/hmrc/traderservices/controllers/AmendCaseJourneyISpec.scala
+++ b/it/uk/gov/hmrc/traderservices/controllers/AmendCaseJourneyISpec.scala
@@ -3,11 +3,11 @@ package uk.gov.hmrc.traderservices.controllers
 import play.api.libs.json.Format
 import play.api.libs.ws.DefaultWSCookie
 import play.api.mvc.Session
-import uk.gov.hmrc.cache.repository.CacheMongoRepository
 import uk.gov.hmrc.crypto.{ApplicationCrypto, PlainText}
 import uk.gov.hmrc.traderservices.connectors.TraderServicesResult
 import uk.gov.hmrc.traderservices.journeys.AmendCaseJourneyStateFormats
 import uk.gov.hmrc.traderservices.models._
+import uk.gov.hmrc.traderservices.repository.CacheRepository
 import uk.gov.hmrc.traderservices.services.{AmendCaseJourneyService, MongoDBCachedJourneyService}
 import uk.gov.hmrc.traderservices.stubs.{TraderServicesApiStubs, UpscanInitiateStubs}
 import uk.gov.hmrc.traderservices.support.{ServerISpec, TestJourneyService}
@@ -1223,7 +1223,7 @@ trait AmendCaseJourneyISpecSetup extends ServerISpec {
   lazy val journey = new TestJourneyService[JourneyId]
     with AmendCaseJourneyService[JourneyId] with MongoDBCachedJourneyService[JourneyId] {
 
-    override lazy val cacheMongoRepository = app.injector.instanceOf[CacheMongoRepository]
+    override lazy val cacheMongoRepository = app.injector.instanceOf[CacheRepository]
     override lazy val applicationCrypto = app.injector.instanceOf[ApplicationCrypto]
 
     override val stateFormats: Format[model.State] =

--- a/it/uk/gov/hmrc/traderservices/controllers/AmendCaseJourneyNoEnrolmentISpec.scala
+++ b/it/uk/gov/hmrc/traderservices/controllers/AmendCaseJourneyNoEnrolmentISpec.scala
@@ -3,11 +3,11 @@ package uk.gov.hmrc.traderservices.controllers
 import play.api.libs.json.Format
 import play.api.libs.ws.DefaultWSCookie
 import play.api.mvc.Session
-import uk.gov.hmrc.cache.repository.CacheMongoRepository
 import uk.gov.hmrc.crypto.{ApplicationCrypto, PlainText}
 import uk.gov.hmrc.traderservices.connectors.TraderServicesResult
 import uk.gov.hmrc.traderservices.journeys.AmendCaseJourneyStateFormats
 import uk.gov.hmrc.traderservices.models._
+import uk.gov.hmrc.traderservices.repository.CacheRepository
 import uk.gov.hmrc.traderservices.services.{AmendCaseJourneyService, MongoDBCachedJourneyService}
 import uk.gov.hmrc.traderservices.stubs.{TraderServicesApiStubs, UpscanInitiateStubs}
 import uk.gov.hmrc.traderservices.support.{ServerISpec, TestJourneyService}
@@ -1124,7 +1124,7 @@ trait AmendCaseJourneyNoEnrolmentISpecSetup extends ServerISpec {
   lazy val journey = new TestJourneyService[JourneyId]
     with AmendCaseJourneyService[JourneyId] with MongoDBCachedJourneyService[JourneyId] {
 
-    override lazy val cacheMongoRepository = app.injector.instanceOf[CacheMongoRepository]
+    override lazy val cacheMongoRepository = app.injector.instanceOf[CacheRepository]
     override lazy val applicationCrypto = app.injector.instanceOf[ApplicationCrypto]
 
     override val stateFormats: Format[model.State] =

--- a/it/uk/gov/hmrc/traderservices/controllers/CreateCaseJourneyISpec.scala
+++ b/it/uk/gov/hmrc/traderservices/controllers/CreateCaseJourneyISpec.scala
@@ -2,12 +2,12 @@ package uk.gov.hmrc.traderservices.controllers
 
 import play.api.libs.json.Format
 import play.api.mvc.Session
-import uk.gov.hmrc.cache.repository.CacheMongoRepository
 import uk.gov.hmrc.crypto.{ApplicationCrypto, PlainText}
 import uk.gov.hmrc.traderservices.connectors.TraderServicesResult
 import uk.gov.hmrc.traderservices.journeys.CreateCaseJourneyModel.FileUploadHostData
 import uk.gov.hmrc.traderservices.journeys.CreateCaseJourneyStateFormats
 import uk.gov.hmrc.traderservices.models.{ExportContactInfo, _}
+import uk.gov.hmrc.traderservices.repository.CacheRepository
 import uk.gov.hmrc.traderservices.services.{CreateCaseJourneyService, MongoDBCachedJourneyService}
 import uk.gov.hmrc.traderservices.stubs.{PdfGeneratorStubs, TraderServicesApiStubs, UpscanInitiateStubs}
 import uk.gov.hmrc.traderservices.support.{ServerISpec, TestData, TestJourneyService}
@@ -2842,7 +2842,7 @@ trait CreateCaseJourneyISpecSetup extends ServerISpec {
   lazy val journey = new TestJourneyService[JourneyId]
     with CreateCaseJourneyService[JourneyId] with MongoDBCachedJourneyService[JourneyId] {
 
-    override lazy val cacheMongoRepository = app.injector.instanceOf[CacheMongoRepository]
+    override lazy val cacheMongoRepository = app.injector.instanceOf[CacheRepository]
     override lazy val applicationCrypto = app.injector.instanceOf[ApplicationCrypto]
 
     override val stateFormats: Format[model.State] =

--- a/it/uk/gov/hmrc/traderservices/controllers/CreateCaseJourneyNoEnrolmentISpec.scala
+++ b/it/uk/gov/hmrc/traderservices/controllers/CreateCaseJourneyNoEnrolmentISpec.scala
@@ -2,12 +2,12 @@ package uk.gov.hmrc.traderservices.controllers
 
 import play.api.libs.json.Format
 import play.api.mvc.Session
-import uk.gov.hmrc.cache.repository.CacheMongoRepository
 import uk.gov.hmrc.crypto.{ApplicationCrypto, PlainText}
 import uk.gov.hmrc.traderservices.connectors.TraderServicesResult
 import uk.gov.hmrc.traderservices.journeys.CreateCaseJourneyModel.FileUploadHostData
 import uk.gov.hmrc.traderservices.journeys.CreateCaseJourneyStateFormats
 import uk.gov.hmrc.traderservices.models.{ExportContactInfo, _}
+import uk.gov.hmrc.traderservices.repository.CacheRepository
 import uk.gov.hmrc.traderservices.services.{CreateCaseJourneyService, MongoDBCachedJourneyService}
 import uk.gov.hmrc.traderservices.stubs.{TraderServicesApiStubs, UpscanInitiateStubs}
 import uk.gov.hmrc.traderservices.support.{ServerISpec, TestData, TestJourneyService}
@@ -2653,7 +2653,7 @@ trait CreateCaseJourneyNoEnrolmentISpecSetup extends ServerISpec {
   lazy val journey = new TestJourneyService[JourneyId]
     with CreateCaseJourneyService[JourneyId] with MongoDBCachedJourneyService[JourneyId] {
 
-    override lazy val cacheMongoRepository = app.injector.instanceOf[CacheMongoRepository]
+    override lazy val cacheMongoRepository = app.injector.instanceOf[CacheRepository]
     override lazy val applicationCrypto = app.injector.instanceOf[ApplicationCrypto]
 
     override val stateFormats: Format[model.State] =

--- a/it/uk/gov/hmrc/traderservices/support/TestAppConfig.scala
+++ b/it/uk/gov/hmrc/traderservices/support/TestAppConfig.scala
@@ -1,6 +1,8 @@
 package uk.gov.hmrc.traderservices.support
 
 import uk.gov.hmrc.traderservices.wiring.AppConfig
+import scala.concurrent.duration.Duration
+import scala.concurrent.duration._
 
 case class TestAppConfig(
   wireMockBaseUrl: String,
@@ -22,7 +24,7 @@ case class TestAppConfig(
   override val createCaseApiPath: String = "/create-case"
   override val updateCaseApiPath: String = "/update-case"
 
-  override val mongoSessionExpiryTime: Int = 3600
+  override val mongoSessionExpiration: Duration = 1.hour
 
   override val gtmContainerId: Option[String] = None
   override val contactHost: String = wireMockBaseUrl


### PR DESCRIPTION
This PR migrates underlying cache implementation to use <https://github.com\hmrc\hmrc-mongo> in line with https://confluence.tools.tax.service.gov.uk/display/TEC/2021/03/04/HMRC+Mongo+is+now+available.