### PR TITLE
[AO] upgrade sbt-auto-build to version 3.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -89,7 +89,7 @@ lazy val root = (project in file("."))
     javaOptions in IntegrationTest += "-Djava.locale.providers=CLDR,JRE"
   )
   .disablePlugins(JUnitXmlReportPlugin) //Required to prevent https://github.com/scalatest/scalatest/issues/1427
-  .enablePlugins(PlayScala, SbtAutoBuildPlugin, SbtGitVersioning, SbtDistributablesPlugin)
+  .enablePlugins(PlayScala, SbtDistributablesPlugin)
 
 inConfig(IntegrationTest)(org.scalafmt.sbt.ScalafmtPlugin.scalafmtConfigSettings)
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,13 +3,11 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts
   Resolver.ivyStylePatterns
 )
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.15.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.0.0")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.9")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
-
-addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.2.0")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
 


### PR DESCRIPTION
This PR applies the changes recommended by https://confluence.tools.tax.service.gov.uk/display/TEC/2021/05/05/New+version+of+sbt-auto-build