### PR TITLE
[DOR-460][AO] do not trim the filename

### DIFF
--- a/app/uk/gov/hmrc/traderservices/models/FileUploads.scala
+++ b/app/uk/gov/hmrc/traderservices/models/FileUploads.scala
@@ -53,7 +53,7 @@ case class FileUploads(
           f.url,
           f.uploadTimestamp,
           f.checksum,
-          FileUpload.trimFileName(f.fileName),
+          f.fileName,
           f.fileMimeType,
           f.fileSize
         )
@@ -113,21 +113,6 @@ object FileUpload extends SealedTraitFormats[FileUpload] {
       case isWindowPathHaving(name) => name
       case name                     => name
     }
-
-  val MAX_FILENAME_LENGTH = 93
-
-  final def trimFileName(filename: String): String =
-    if (filename.length() > MAX_FILENAME_LENGTH) {
-      val (name, extension) = {
-        val i = filename.lastIndexOf(".")
-        if (i >= 0 && i < filename.length()) (filename.substring(0, i), filename.substring(i))
-        else (filename, "")
-      }
-      val nameFiltered = name.filter(Character.isLetterOrDigit)
-      (if (nameFiltered.nonEmpty) nameFiltered else name)
-        .take(MAX_FILENAME_LENGTH - extension.length()) + extension
-    } else
-      filename
 
   /**
     * Status when file upload attributes has been requested from upscan-initiate

--- a/app/uk/gov/hmrc/traderservices/models/FileVerificationStatus.scala
+++ b/app/uk/gov/hmrc/traderservices/models/FileVerificationStatus.scala
@@ -16,12 +16,10 @@
 
 package uk.gov.hmrc.traderservices.models
 
-import play.api.libs.json.{Format, Json}
-import uk.gov.hmrc.traderservices.views.UploadFileViewContext
 import play.api.i18n.Messages
+import play.api.libs.json.{Format, Json}
 import play.api.mvc.Call
-import java.net.URLEncoder
-import java.nio.charset.StandardCharsets
+import uk.gov.hmrc.traderservices.views.UploadFileViewContext
 
 case class FileVerificationStatus(
   reference: String,

--- a/test/uk/gov/hmrc/traderservices/models/FileUploadsSpec.scala
+++ b/test/uk/gov/hmrc/traderservices/models/FileUploadsSpec.scala
@@ -217,37 +217,6 @@ class FileUploadsSpec extends UnitSpec {
       ) shouldBe "0000Chry*[(anth]?)emum\u1213jpg"
     }
 
-    "trim the file name" in {
-      val MAX = FileUpload.MAX_FILENAME_LENGTH
-
-      FileUpload.trimFileName("") shouldBe ""
-      FileUpload.trimFileName("a") shouldBe "a"
-      FileUpload.trimFileName("a.a") shouldBe "a.a"
-      FileUpload.trimFileName("a" * MAX) shouldBe "a" * MAX
-      FileUpload.trimFileName("a" * (MAX + 1)) shouldBe "a" * MAX
-      FileUpload.trimFileName("a" * (MAX - 5) + ".ext") shouldBe "a" * (MAX - 5) + ".ext"
-      FileUpload.trimFileName("a" * (MAX - 4) + ".ext") shouldBe "a" * (MAX - 4) + ".ext"
-      FileUpload.trimFileName("a" * (MAX + 1) + ".ext") shouldBe "a" * (MAX - 4) + ".ext"
-      FileUpload.trimFileName("a" * (MAX - 2) + ".") shouldBe "a" * (MAX - 2) + "."
-      FileUpload.trimFileName("a" * (MAX - 1) + ".") shouldBe "a" * (MAX - 1) + "."
-      FileUpload.trimFileName("a" * MAX + ".") shouldBe "a" * (MAX - 1) + "."
-      FileUpload.trimFileName("-" * MAX) shouldBe "-" * MAX
-      FileUpload.trimFileName("-" * (MAX - 5) + ".ext") shouldBe "-" * (MAX - 5) + ".ext"
-      FileUpload.trimFileName("-" * (MAX - 4) + ".ext") shouldBe "-" * (MAX - 4) + ".ext"
-      FileUpload.trimFileName("-" * (MAX + 1) + ".ext") shouldBe "-" * (MAX - 4) + ".ext"
-
-      FileUpload.trimFileName(
-        "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus tempor egestas viverra usce."
-      ) shouldBe "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus tempor egestas viverra usce."
-      FileUpload.trimFileName(
-        "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum cursus, erat sed fringilla lacinia, sem nulla vulputate mauris, at tincidunt eros.ext"
-      ) shouldBe "LoremipsumdolorsitametconsecteturadipiscingelitVestibulumcursuseratsedfringillalaciniasem.ext"
-      FileUpload.trimFileName(
-        "123orem_ipsum_dolor_sit_amet-----consec9999999999tetur-adipiscing elit_Vestibulum***12cursus,!!![erat]+sed+fringilla (lacinia), sem/nulla/vulputate /_mauris,~at&tincidunt@eros.ext"
-      ) shouldBe "123oremipsumdolorsitametconsec9999999999teturadipiscingelitVestibulum12cursuseratsedfring.ext"
-
-    }
-
     "count accepted" in {
       FileUploads(
         files = Seq(
@@ -285,10 +254,6 @@ class FileUploadsSpec extends UnitSpec {
       failedFileUpload.isReady shouldBe true
       rejectedFileUpload.isReady shouldBe true
       duplicateFileUpload.isReady shouldBe true
-    }
-
-    "have MAX_FILENAME_LENGTH" in {
-      FileUpload.MAX_FILENAME_LENGTH shouldBe 93
     }
   }
 }


### PR DESCRIPTION
This PR removes trimming of the filename because it will be now performed in the file-transmission-synchronous service.