### PR TITLE
DDCYLS-8592 Route1:Error message not associated with its input

### DIFF
--- a/app/assets/javascripts/tools/error-manager.tool.ts
+++ b/app/assets/javascripts/tools/error-manager.tool.ts
@@ -65,6 +65,8 @@ export default class ErrorManager {
     error.errorSummaryRow.remove();
 
     inputContainer.classList.remove(this.classes.inputContainerError);
+    this.removeDescribedBy(input, error.errorMessage.id);
+    input.removeAttribute('aria-invalid');
 
     delete this.errors[inputId];
 
@@ -81,10 +83,13 @@ export default class ErrorManager {
     const label = this.getLabel(inputContainer);
 
     const errorMessage = parseHtml(this.errorMessageTpl, {
+      inputId: inputId,
       errorMessage: message
     });
 
     inputContainer.classList.add(this.classes.inputContainerError);
+    this.addDescribedBy(input, errorMessage.id);
+    input.setAttribute('aria-invalid', 'true');
 
     label.after(errorMessage);
 
@@ -130,5 +135,29 @@ export default class ErrorManager {
 
   private getLabel(container: HTMLElement): HTMLLabelElement {
     return container.querySelector(`.${this.classes.label}`);
+  }
+
+  private addDescribedBy(input: HTMLElement, targetId: string): void {
+    const currentValue = input.getAttribute('aria-describedby') || '';
+    const describedByIds = currentValue.split(/\s+/).filter(Boolean);
+
+    if (!describedByIds.includes(targetId)) {
+      describedByIds.push(targetId);
+      input.setAttribute('aria-describedby', describedByIds.join(' '));
+    }
+  }
+
+  private removeDescribedBy(input: HTMLElement, targetId: string): void {
+    const currentValue = input.getAttribute('aria-describedby') || '';
+    const describedByIds = currentValue
+      .split(/\s+/)
+      .filter(Boolean)
+      .filter((id) => id !== targetId);
+
+    if (describedByIds.length > 0) {
+      input.setAttribute('aria-describedby', describedByIds.join(' '));
+    } else {
+      input.removeAttribute('aria-describedby');
+    }
   }
 }

--- a/app/assets/spec/components/multi-file-upload.spec.js
+++ b/app/assets/spec/components/multi-file-upload.spec.js
@@ -96,7 +96,7 @@ describe('Multi File Upload component', () => {
           </script>
 
           <script type="text/x-template" id="error-manager-message-tpl">
-            <span class="govuk-error-message">
+            <span id="{inputId}-error" class="govuk-error-message">
               <span class="multi-file-upload__error-message">{errorMessage}</span>
             </span>
           </script>

--- a/app/assets/spec/tools/error-manager.tool.spec.js
+++ b/app/assets/spec/tools/error-manager.tool.spec.js
@@ -27,7 +27,7 @@ describe('ErrorManager tool', () => {
           </script>
 
           <script type="text/x-template" id="error-manager-message-tpl">
-            <span class="govuk-error-message">
+            <span id="{inputId}-error" class="govuk-error-message">
               <span class="multi-file-upload__error-message">{errorMessage}</span>
             </span>
           </script>
@@ -77,6 +77,14 @@ describe('ErrorManager tool', () => {
 
             expect(item.querySelector('.govuk-error-message').textContent.trim()).toEqual('message');
           });
+
+          it('Then the field references its error message', () => {
+            expect(document.getElementById('input').getAttribute('aria-describedby')).toEqual('input-error');
+          });
+
+          it('Then the field is marked as invalid', () => {
+            expect(document.getElementById('input').getAttribute('aria-invalid')).toEqual('true');
+          });
         });
 
         describe('And an error is already added to the field', () => {
@@ -113,6 +121,14 @@ describe('ErrorManager tool', () => {
 
             it('Then the error gets removed from the field', () => {
               expect(document.querySelector('#item .govuk-error-message')).toEqual(null);
+            });
+
+            it('Then the field no longer references the error message', () => {
+              expect(document.getElementById('input').hasAttribute('aria-describedby')).toEqual(false);
+            });
+
+            it('Then the field is no longer marked as invalid', () => {
+              expect(document.getElementById('input').hasAttribute('aria-invalid')).toEqual(false);
             });
 
             it('Then the summary gets detached from DOM', () => {

--- a/app/uk/gov/hmrc/traderservices/views/partials/errorManager/message.scala.html
+++ b/app/uk/gov/hmrc/traderservices/views/partials/errorManager/message.scala.html
@@ -15,7 +15,7 @@
  *@
 
 @(implicit messages: Messages)
-<span id="contactEmail-error" class="govuk-error-message">
+<span id="{inputId}-error" class="govuk-error-message">
   <span class="govuk-visually-hidden">@messages("error.prefix")</span>
   <span class="multi-file-upload__error-message">{errorMessage}</span>
 </span>


### PR DESCRIPTION
Changes - 

Fixed upload field error message accessibility association

- Amended message.scala.html
- Amended error-manager.tool.ts
- Amended error-manager.tool.spec.js
- Amended multi-file-upload.spec.js